### PR TITLE
chore: smaller `crypto` library

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a2d3a37dcf7f1da6a4ece98916a17c80f30e71d3cdc1a1fe342d602518cbb115",
+  "checksum": "5c080ad29008536139e421c555b45f1cc827e676837f5ba17d56431108ca124d",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -70,56 +70,6 @@
       },
       "license": "0BSD OR MIT OR Apache-2.0"
     },
-    "aes 0.8.3": {
-      "name": "aes",
-      "version": "0.8.3",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/aes/0.8.3/download",
-          "sha256": "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "aes",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "aes",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.0",
-              "target": "cfg_if"
-            },
-            {
-              "id": "cipher 0.4.4",
-              "target": "cipher"
-            }
-          ],
-          "selects": {
-            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
-              {
-                "id": "cpufeatures 0.2.12",
-                "target": "cpufeatures"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "0.8.3"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "aho-corasick 1.1.2": {
       "name": "aho-corasick",
       "version": "1.1.2",
@@ -145,22 +95,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "perf-literal",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "memchr 2.7.1",
-              "target": "memchr"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
         "version": "1.1.2"
       },
@@ -630,66 +564,6 @@
         ],
         "edition": "2018",
         "version": "1.6.0"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "arrayref 0.3.7": {
-      "name": "arrayref",
-      "version": "0.3.7",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/arrayref/0.3.7/download",
-          "sha256": "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "arrayref",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "arrayref",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.3.7"
-      },
-      "license": "BSD-2-Clause"
-    },
-    "arrayvec 0.7.4": {
-      "name": "arrayvec",
-      "version": "0.7.4",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/arrayvec/0.7.4/download",
-          "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "arrayvec",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "arrayvec",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.7.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2140,60 +2014,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "blake2b_simd 1.0.2": {
-      "name": "blake2b_simd",
-      "version": "1.0.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/blake2b_simd/1.0.2/download",
-          "sha256": "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "blake2b_simd",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "blake2b_simd",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "arrayref 0.3.7",
-              "target": "arrayref"
-            },
-            {
-              "id": "arrayvec 0.7.4",
-              "target": "arrayvec"
-            },
-            {
-              "id": "constant_time_eq 0.3.0",
-              "target": "constant_time_eq"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.0.2"
-      },
-      "license": "MIT"
-    },
     "block-buffer 0.10.4": {
       "name": "block-buffer",
       "version": "0.10.4",
@@ -3184,36 +3004,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "constant_time_eq 0.3.0": {
-      "name": "constant_time_eq",
-      "version": "0.3.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.3.0/download",
-          "sha256": "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "constant_time_eq",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "constant_time_eq",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.3.0"
-      },
-      "license": "CC0-1.0 OR MIT-0 OR Apache-2.0"
-    },
     "cookie-factory 0.3.2": {
       "name": "cookie-factory",
       "version": "0.3.2",
@@ -3927,40 +3717,12 @@
         "deps": {
           "common": [
             {
-              "id": "aes 0.8.3",
-              "target": "aes"
-            },
-            {
               "id": "anyhow 1.0.79",
               "target": "anyhow"
             },
             {
-              "id": "fpe 0.6.1",
-              "target": "fpe"
-            },
-            {
               "id": "hex 0.4.3",
               "target": "hex"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            },
-            {
-              "id": "regex 1.10.3",
-              "target": "regex"
-            },
-            {
-              "id": "ring 0.17.7",
-              "target": "ring"
-            },
-            {
-              "id": "rust-argon2 2.1.0",
-              "target": "argon2"
             }
           ],
           "selects": {}
@@ -3970,6 +3732,10 @@
             {
               "id": "criterion 0.5.1",
               "target": "criterion"
+            },
+            {
+              "id": "regex-lite 0.1.5",
+              "target": "regex_lite"
             }
           ],
           "selects": {}
@@ -5590,76 +5356,6 @@
         "version": "1.2.1"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "fpe 0.6.1": {
-      "name": "fpe",
-      "version": "0.6.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/fpe/0.6.1/download",
-          "sha256": "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "fpe",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "fpe",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "num-bigint",
-            "num-integer",
-            "num-traits",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cbc 0.1.2",
-              "target": "cbc"
-            },
-            {
-              "id": "cipher 0.4.4",
-              "target": "cipher"
-            },
-            {
-              "id": "libm 0.2.8",
-              "target": "libm"
-            },
-            {
-              "id": "num-bigint 0.4.4",
-              "target": "num_bigint"
-            },
-            {
-              "id": "num-integer 0.1.45",
-              "target": "num_integer"
-            },
-            {
-              "id": "num-traits 0.2.17",
-              "target": "num_traits"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.6.1"
-      },
-      "license": "MIT/Apache-2.0"
     },
     "futures 0.3.30": {
       "name": "futures",
@@ -8986,79 +8682,10 @@
         "crate_features": {
           "common": [
             "default",
+            "extra_traits",
             "std"
           ],
-          "selects": {
-            "aarch64-apple-darwin": [
-              "extra_traits"
-            ],
-            "aarch64-apple-ios": [
-              "extra_traits"
-            ],
-            "aarch64-apple-ios-sim": [
-              "extra_traits"
-            ],
-            "aarch64-fuchsia": [
-              "extra_traits"
-            ],
-            "aarch64-linux-android": [
-              "extra_traits"
-            ],
-            "armv7-linux-androideabi": [
-              "extra_traits"
-            ],
-            "i686-apple-darwin": [
-              "extra_traits"
-            ],
-            "i686-linux-android": [
-              "extra_traits"
-            ],
-            "i686-unknown-freebsd": [
-              "extra_traits"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "extra_traits"
-            ],
-            "riscv32imc-unknown-none-elf": [
-              "extra_traits"
-            ],
-            "riscv64gc-unknown-none-elf": [
-              "extra_traits"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "extra_traits"
-            ],
-            "thumbv7em-none-eabi": [
-              "extra_traits"
-            ],
-            "thumbv8m.main-none-eabi": [
-              "extra_traits"
-            ],
-            "wasm32-unknown-unknown": [
-              "extra_traits"
-            ],
-            "wasm32-wasi": [
-              "extra_traits"
-            ],
-            "x86_64-apple-darwin": [
-              "extra_traits"
-            ],
-            "x86_64-apple-ios": [
-              "extra_traits"
-            ],
-            "x86_64-fuchsia": [
-              "extra_traits"
-            ],
-            "x86_64-linux-android": [
-              "extra_traits"
-            ],
-            "x86_64-unknown-freebsd": [
-              "extra_traits"
-            ],
-            "x86_64-unknown-none": [
-              "extra_traits"
-            ]
-          }
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -9071,65 +8698,6 @@
         },
         "edition": "2015",
         "version": "0.2.152"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "libm 0.2.8": {
-      "name": "libm",
-      "version": "0.2.8",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/libm/0.2.8/download",
-          "sha256": "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "libm",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "libm",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "libm 0.2.8",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.2.8"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9173,6 +8741,9 @@
             "aarch64-unknown-linux-gnu": [
               "errno"
             ],
+            "aarch64-unknown-nixos-gnu": [
+              "errno"
+            ],
             "arm-unknown-linux-gnueabi": [
               "errno"
             ],
@@ -9183,6 +8754,9 @@
               "errno"
             ],
             "x86_64-unknown-linux-gnu": [
+              "errno"
+            ],
+            "x86_64-unknown-nixos-gnu": [
               "errno"
             ]
           }
@@ -9219,89 +8793,43 @@
         ],
         "crate_features": {
           "common": [
-            "elf",
-            "errno",
             "general",
+            "if_ether",
             "ioctl",
-            "no_std"
+            "net",
+            "netlink",
+            "no_std",
+            "prctl",
+            "xdp"
           ],
           "selects": {
-            "aarch64-linux-android": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
             "aarch64-unknown-linux-gnu": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
+              "elf",
+              "errno"
+            ],
+            "aarch64-unknown-nixos-gnu": [
+              "elf",
+              "errno"
             ],
             "arm-unknown-linux-gnueabi": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
-            "armv7-linux-androideabi": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
+              "elf",
+              "errno"
             ],
             "armv7-unknown-linux-gnueabi": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
-            "i686-linux-android": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
+              "elf",
+              "errno"
             ],
             "i686-unknown-linux-gnu": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
-            "powerpc-unknown-linux-gnu": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
-            "s390x-unknown-linux-gnu": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
-            ],
-            "x86_64-linux-android": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
+              "elf",
+              "errno"
             ],
             "x86_64-unknown-linux-gnu": [
-              "if_ether",
-              "net",
-              "netlink",
-              "prctl",
-              "xdp"
+              "elf",
+              "errno"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "elf",
+              "errno"
             ]
           }
         },
@@ -13105,36 +12633,13 @@
         ],
         "crate_features": {
           "common": [
-            "default",
-            "perf",
-            "perf-backtrack",
-            "perf-cache",
-            "perf-dfa",
-            "perf-inline",
-            "perf-literal",
-            "perf-onepass",
             "std",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment"
+            "unicode-bool"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
-            {
-              "id": "aho-corasick 1.1.2",
-              "target": "aho_corasick"
-            },
-            {
-              "id": "memchr 2.7.1",
-              "target": "memchr"
-            },
             {
               "id": "regex-automata 0.4.4",
               "target": "regex_automata"
@@ -13179,40 +12684,17 @@
         "crate_features": {
           "common": [
             "alloc",
-            "dfa-onepass",
-            "hybrid",
             "meta",
-            "nfa-backtrack",
             "nfa-pikevm",
             "nfa-thompson",
-            "perf-inline",
-            "perf-literal",
-            "perf-literal-multisubstring",
-            "perf-literal-substring",
             "std",
             "syntax",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment",
-            "unicode-word-boundary"
+            "unicode-bool"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
-            {
-              "id": "aho-corasick 1.1.2",
-              "target": "aho_corasick"
-            },
-            {
-              "id": "memchr 2.7.1",
-              "target": "memchr"
-            },
             {
               "id": "regex-syntax 0.8.2",
               "target": "regex_syntax"
@@ -13290,16 +12772,8 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "std",
-            "unicode",
-            "unicode-age",
-            "unicode-bool",
-            "unicode-case",
-            "unicode-gencat",
-            "unicode-perl",
-            "unicode-script",
-            "unicode-segment"
+            "unicode-bool"
           ],
           "selects": {}
         },
@@ -13617,53 +13091,6 @@
       },
       "license": null
     },
-    "rust-argon2 2.1.0": {
-      "name": "rust-argon2",
-      "version": "2.1.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/rust-argon2/2.1.0/download",
-          "sha256": "9d9848531d60c9cbbcf9d166c885316c24bc0e2a9d3eba0956bb6cbbd79bc6e8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "argon2",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "argon2",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "base64 0.21.7",
-              "target": "base64"
-            },
-            {
-              "id": "blake2b_simd 1.0.2",
-              "target": "blake2b_simd"
-            },
-            {
-              "id": "constant_time_eq 0.3.0",
-              "target": "constant_time_eq"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.1.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "rustc-demangle 0.1.23": {
       "name": "rustc-demangle",
       "version": "0.1.23",
@@ -13884,6 +13311,20 @@
               "termios",
               "time"
             ],
+            "aarch64-unknown-nixos-gnu": [
+              "event",
+              "pipe",
+              "process",
+              "termios",
+              "time"
+            ],
+            "aarch64-unknown-nto-qnx710": [
+              "event",
+              "pipe",
+              "process",
+              "termios",
+              "time"
+            ],
             "arm-unknown-linux-gnueabi": [
               "event",
               "pipe",
@@ -14004,6 +13445,13 @@
               "termios",
               "time"
             ],
+            "x86_64-unknown-nixos-gnu": [
+              "event",
+              "pipe",
+              "process",
+              "termios",
+              "time"
+            ],
             "x86_64-unknown-none": [
               "termios"
             ]
@@ -14028,11 +13476,6 @@
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
-              {
-                "id": "errno 0.3.8",
-                "target": "errno",
-                "alias": "libc_errno"
-              },
               {
                 "id": "linux-raw-sys 0.4.12",
                 "target": "linux_raw_sys"
@@ -21082,6 +20525,12 @@
     "aarch64-unknown-linux-gnu": [
       "aarch64-unknown-linux-gnu"
     ],
+    "aarch64-unknown-nixos-gnu": [
+      "aarch64-unknown-nixos-gnu"
+    ],
+    "aarch64-unknown-nto-qnx710": [
+      "aarch64-unknown-nto-qnx710"
+    ],
     "arm-unknown-linux-gnueabi": [
       "arm-unknown-linux-gnueabi"
     ],
@@ -21113,23 +20562,28 @@
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-unknown-linux-gnueabi",
       "i686-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-unknown-linux-gnueabi",
       "i686-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
       "aarch64-apple-darwin",
@@ -21137,6 +20591,7 @@
       "aarch64-apple-ios-sim",
       "aarch64-fuchsia",
       "aarch64-linux-android",
+      "aarch64-unknown-nto-qnx710",
       "armv7-linux-androideabi",
       "i686-apple-darwin",
       "i686-linux-android",
@@ -21162,6 +20617,7 @@
       "aarch64-apple-ios-sim",
       "aarch64-fuchsia",
       "aarch64-linux-android",
+      "aarch64-unknown-nto-qnx710",
       "armv7-linux-androideabi",
       "i686-apple-darwin",
       "i686-linux-android",
@@ -21185,7 +20641,8 @@
       "aarch64-pc-windows-msvc"
     ],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
-      "aarch64-unknown-linux-gnu"
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu"
     ],
     "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
       "aarch64-pc-windows-msvc"
@@ -21209,7 +20666,8 @@
       "i686-pc-windows-msvc"
     ],
     "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
@@ -21220,6 +20678,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21232,7 +20692,8 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
@@ -21242,6 +20703,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21259,6 +20722,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
@@ -21269,6 +20733,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "i686-apple-darwin",
       "i686-linux-android",
       "i686-pc-windows-msvc",
@@ -21281,6 +20747,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
@@ -21291,6 +20758,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "i686-apple-darwin",
       "i686-linux-android",
       "i686-pc-windows-msvc",
@@ -21303,6 +20772,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
@@ -21320,6 +20790,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21334,7 +20806,8 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(any(unix, target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
@@ -21343,6 +20816,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21358,7 +20833,8 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(any(windows, unix, target_os = \"redox\"))": [
       "aarch64-apple-darwin",
@@ -21368,6 +20844,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21384,7 +20862,8 @@
       "x86_64-linux-android",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
       "aarch64-apple-darwin",
@@ -21393,6 +20872,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21414,12 +20895,15 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(any(target_os = \"windows\", target_os = \"macos\", target_os = \"ios\")))": [
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21438,6 +20922,7 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
@@ -21447,6 +20932,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21467,6 +20954,7 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(target_arch = \"wasm32\"))": [
@@ -21477,6 +20965,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21498,6 +20988,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(target_family = \"wasm\"))": [
@@ -21508,6 +20999,8 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21529,6 +21022,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(windows))": [
@@ -21538,6 +21032,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21559,6 +21055,7 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(target_arch = \"spirv\")": [],
@@ -21597,6 +21094,8 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-nixos-gnu",
+      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21611,7 +21110,8 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(windows)": [
       "aarch64-pc-windows-msvc",
@@ -21681,8 +21181,48 @@
     "x86_64-unknown-linux-gnu": [
       "x86_64-unknown-linux-gnu"
     ],
+    "x86_64-unknown-nixos-gnu": [
+      "x86_64-unknown-nixos-gnu"
+    ],
     "x86_64-unknown-none": [
       "x86_64-unknown-none"
     ]
-  }
+  },
+  "direct_deps": [
+    "anyhow 1.0.79",
+    "async-trait 0.1.77",
+    "chrono 0.4.33",
+    "cloudinary 0.4.0",
+    "fast_image_resize 3.0.2",
+    "fern 0.6.2",
+    "futures-executor 0.3.30",
+    "hex 0.4.3",
+    "image 0.24.8",
+    "isolang 2.4.0",
+    "jsonwebtoken 9.2.0",
+    "kafka 0.10.0",
+    "lapin 2.3.1",
+    "lazy_static 1.4.0",
+    "log 0.4.20",
+    "memcache 0.17.2",
+    "prost 0.12.3",
+    "prost-types 0.12.3",
+    "r2d2 0.8.10",
+    "regex-lite 0.1.5",
+    "reqwest 0.11.24",
+    "scylla 0.12.0",
+    "serde 1.0.196",
+    "serde_json 1.0.113",
+    "serde_yaml 0.9.31",
+    "tempfile 3.10.0",
+    "tokio 1.36.0",
+    "tonic 0.10.2",
+    "tonic-build 0.10.2",
+    "totp-lite 2.0.1",
+    "uuid 1.7.0",
+    "warp 0.3.6"
+  ],
+  "direct_dev_deps": [
+    "criterion 0.5.1"
+  ]
 }

--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5c080ad29008536139e421c555b45f1cc827e676837f5ba17d56431108ca124d",
+  "checksum": "1dabc375a8e628bb7cb22fd4df4dd6b6563409e0709332251d8cfdfd43e157c9",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -69,6 +69,56 @@
         "version": "1.0.2"
       },
       "license": "0BSD OR MIT OR Apache-2.0"
+    },
+    "aes 0.8.3": {
+      "name": "aes",
+      "version": "0.8.3",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/aes/0.8.3/download",
+          "sha256": "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "aes",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "aes",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "cipher 0.4.4",
+              "target": "cipher"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
+              {
+                "id": "cpufeatures 0.2.12",
+                "target": "cpufeatures"
+              }
+            ]
+          }
+        },
+        "edition": "2021",
+        "version": "0.8.3"
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "aho-corasick 1.1.2": {
       "name": "aho-corasick",
@@ -564,6 +614,66 @@
         ],
         "edition": "2018",
         "version": "1.6.0"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "arrayref 0.3.7": {
+      "name": "arrayref",
+      "version": "0.3.7",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/arrayref/0.3.7/download",
+          "sha256": "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arrayref",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "arrayref",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.3.7"
+      },
+      "license": "BSD-2-Clause"
+    },
+    "arrayvec 0.7.4": {
+      "name": "arrayvec",
+      "version": "0.7.4",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/arrayvec/0.7.4/download",
+          "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arrayvec",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "arrayvec",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.7.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1912,36 +2022,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "bit_field 0.10.2": {
-      "name": "bit_field",
-      "version": "0.10.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/bit_field/0.10.2/download",
-          "sha256": "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "bit_field",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "bit_field",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.10.2"
-      },
-      "license": "Apache-2.0/MIT"
-    },
     "bitflags 1.3.2": {
       "name": "bitflags",
       "version": "1.3.2",
@@ -2013,6 +2093,60 @@
         "version": "2.4.1"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "blake2b_simd 1.0.2": {
+      "name": "blake2b_simd",
+      "version": "1.0.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/blake2b_simd/1.0.2/download",
+          "sha256": "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "blake2b_simd",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "blake2b_simd",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "arrayref 0.3.7",
+              "target": "arrayref"
+            },
+            {
+              "id": "arrayvec 0.7.4",
+              "target": "arrayvec"
+            },
+            {
+              "id": "constant_time_eq 0.3.0",
+              "target": "constant_time_eq"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "1.0.2"
+      },
+      "license": "MIT"
     },
     "block-buffer 0.10.4": {
       "name": "block-buffer",
@@ -3004,6 +3138,36 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
+    "constant_time_eq 0.3.0": {
+      "name": "constant_time_eq",
+      "version": "0.3.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/constant_time_eq/0.3.0/download",
+          "sha256": "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "constant_time_eq",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "constant_time_eq",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.3.0"
+      },
+      "license": "CC0-1.0 OR MIT-0 OR Apache-2.0"
+    },
     "cookie-factory 0.3.2": {
       "name": "cookie-factory",
       "version": "0.3.2",
@@ -3641,59 +3805,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crunchy 0.2.2": {
-      "name": "crunchy",
-      "version": "0.2.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/crunchy/0.2.2/download",
-          "sha256": "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crunchy",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "crunchy",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "crunchy 0.2.2",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.2.2"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT"
-    },
     "crypto 0.1.0": {
       "name": "crypto",
       "version": "0.1.0",
@@ -3714,15 +3825,41 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "aes",
+            "argon2",
+            "format_preserving",
+            "fpe",
+            "rust-argon2"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
+            {
+              "id": "aes 0.8.3",
+              "target": "aes"
+            },
             {
               "id": "anyhow 1.0.79",
               "target": "anyhow"
             },
             {
+              "id": "fpe 0.6.1",
+              "target": "fpe"
+            },
+            {
               "id": "hex 0.4.3",
               "target": "hex"
+            },
+            {
+              "id": "ring 0.17.7",
+              "target": "ring"
+            },
+            {
+              "id": "rust-argon2 2.1.0",
+              "target": "argon2"
             }
           ],
           "selects": {}
@@ -4014,44 +4151,6 @@
         },
         "edition": "2018",
         "version": "5.5.3"
-      },
-      "license": "MIT"
-    },
-    "data-encoding 2.5.0": {
-      "name": "data-encoding",
-      "version": "2.5.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/data-encoding/2.5.0/download",
-          "sha256": "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "data_encoding",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "data_encoding",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.5.0"
       },
       "license": "MIT"
     },
@@ -4750,73 +4849,6 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "exr 1.71.0": {
-      "name": "exr",
-      "version": "1.71.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/exr/1.71.0/download",
-          "sha256": "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "exr",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "exr",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "bit_field 0.10.2",
-              "target": "bit_field"
-            },
-            {
-              "id": "flume 0.11.0",
-              "target": "flume"
-            },
-            {
-              "id": "half 2.2.1",
-              "target": "half"
-            },
-            {
-              "id": "lebe 0.5.2",
-              "target": "lebe"
-            },
-            {
-              "id": "miniz_oxide 0.7.1",
-              "target": "miniz_oxide"
-            },
-            {
-              "id": "rayon-core 1.12.0",
-              "target": "rayon_core"
-            },
-            {
-              "id": "smallvec 1.11.2",
-              "target": "smallvec"
-            },
-            {
-              "id": "zune-inflate 0.2.54",
-              "target": "zune_inflate"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "1.71.0"
-      },
-      "license": "BSD-3-Clause"
-    },
     "fast_image_resize 3.0.2": {
       "name": "fast_image_resize",
       "version": "3.0.2",
@@ -5356,6 +5388,76 @@
         "version": "1.2.1"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "fpe 0.6.1": {
+      "name": "fpe",
+      "version": "0.6.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/fpe/0.6.1/download",
+          "sha256": "26c4b37de5ae15812a764c958297cfc50f5c010438f60c6ce75d11b802abd404"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "fpe",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "fpe",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "num-bigint",
+            "num-integer",
+            "num-traits",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cbc 0.1.2",
+              "target": "cbc"
+            },
+            {
+              "id": "cipher 0.4.4",
+              "target": "cipher"
+            },
+            {
+              "id": "libm 0.2.8",
+              "target": "libm"
+            },
+            {
+              "id": "num-bigint 0.4.4",
+              "target": "num_bigint"
+            },
+            {
+              "id": "num-integer 0.1.45",
+              "target": "num_integer"
+            },
+            {
+              "id": "num-traits 0.2.17",
+              "target": "num_traits"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.6.1"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "futures 0.3.30": {
       "name": "futures",
@@ -6134,58 +6236,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gif 0.12.0": {
-      "name": "gif",
-      "version": "0.12.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/gif/0.12.0/download",
-          "sha256": "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "gif",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "gif",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "color_quant",
-            "default",
-            "raii_no_panic",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "color_quant 1.1.0",
-              "target": "color_quant"
-            },
-            {
-              "id": "weezl 0.1.7",
-              "target": "weezl"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.12.0"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "gimli 0.28.1": {
       "name": "gimli",
       "version": "0.28.1",
@@ -6322,55 +6372,6 @@
         ],
         "edition": "2018",
         "version": "1.8.2"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "half 2.2.1": {
-      "name": "half",
-      "version": "2.2.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/half/2.2.1/download",
-          "sha256": "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "half",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "half",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [],
-          "selects": {
-            "cfg(target_arch = \"spirv\")": [
-              {
-                "id": "crunchy 0.2.2",
-                "target": "crunchy"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "version": "2.2.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7451,23 +7452,8 @@
         ],
         "crate_features": {
           "common": [
-            "bmp",
-            "dds",
-            "default",
-            "dxt",
-            "exr",
-            "farbfeld",
-            "gif",
-            "hdr",
-            "ico",
             "jpeg",
-            "jpeg_rayon",
-            "openexr",
             "png",
-            "pnm",
-            "qoi",
-            "tga",
-            "tiff",
             "webp"
           ],
           "selects": {}
@@ -7487,14 +7473,6 @@
               "target": "color_quant"
             },
             {
-              "id": "exr 1.71.0",
-              "target": "exr"
-            },
-            {
-              "id": "gif 0.12.0",
-              "target": "gif"
-            },
-            {
               "id": "jpeg-decoder 0.3.0",
               "target": "jpeg_decoder",
               "alias": "jpeg"
@@ -7506,14 +7484,6 @@
             {
               "id": "png 0.17.10",
               "target": "png"
-            },
-            {
-              "id": "qoi 0.4.1",
-              "target": "qoi"
-            },
-            {
-              "id": "tiff 0.9.0",
-              "target": "tiff"
             }
           ],
           "selects": {}
@@ -8204,21 +8174,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "rayon"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "rayon 1.8.0",
-              "target": "rayon"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "0.3.0"
       },
@@ -8380,14 +8335,11 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "flate2",
             "gzip",
             "openssl",
             "openssl-sys",
-            "security",
-            "snap",
-            "snappy"
+            "security"
           ],
           "selects": {}
         },
@@ -8424,10 +8376,6 @@
             {
               "id": "ref_slice 1.2.1",
               "target": "ref_slice"
-            },
-            {
-              "id": "snap 1.1.1",
-              "target": "snap"
             },
             {
               "id": "thiserror 1.0.56",
@@ -8615,36 +8563,6 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "lebe 0.5.2": {
-      "name": "lebe",
-      "version": "0.5.2",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/lebe/0.5.2/download",
-          "sha256": "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "lebe",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "lebe",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.5.2"
-      },
-      "license": "BSD-3-Clause"
-    },
     "libc 0.2.152": {
       "name": "libc",
       "version": "0.2.152",
@@ -8706,6 +8624,65 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "libm 0.2.8": {
+      "name": "libm",
+      "version": "0.2.8",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/libm/0.2.8/download",
+          "sha256": "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libm",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "libm",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "libm 0.2.8",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.2.8"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "linux-raw-sys 0.3.8": {
       "name": "linux-raw-sys",
       "version": "0.3.8",
@@ -8741,9 +8718,6 @@
             "aarch64-unknown-linux-gnu": [
               "errno"
             ],
-            "aarch64-unknown-nixos-gnu": [
-              "errno"
-            ],
             "arm-unknown-linux-gnueabi": [
               "errno"
             ],
@@ -8754,9 +8728,6 @@
               "errno"
             ],
             "x86_64-unknown-linux-gnu": [
-              "errno"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "errno"
             ]
           }
@@ -8807,10 +8778,6 @@
               "elf",
               "errno"
             ],
-            "aarch64-unknown-nixos-gnu": [
-              "elf",
-              "errno"
-            ],
             "arm-unknown-linux-gnueabi": [
               "elf",
               "errno"
@@ -8824,10 +8791,6 @@
               "errno"
             ],
             "x86_64-unknown-linux-gnu": [
-              "elf",
-              "errno"
-            ],
-            "x86_64-unknown-nixos-gnu": [
               "elf",
               "errno"
             ]
@@ -9399,110 +9362,6 @@
         },
         "edition": "2018",
         "version": "0.8.10"
-      },
-      "license": "MIT"
-    },
-    "multer 2.1.0": {
-      "name": "multer",
-      "version": "2.1.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/multer/2.1.0/download",
-          "sha256": "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "multer",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "multer",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytes 1.5.0",
-              "target": "bytes"
-            },
-            {
-              "id": "encoding_rs 0.8.33",
-              "target": "encoding_rs"
-            },
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "http 0.2.11",
-              "target": "http"
-            },
-            {
-              "id": "httparse 1.8.0",
-              "target": "httparse"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "memchr 2.7.1",
-              "target": "memchr"
-            },
-            {
-              "id": "mime 0.3.17",
-              "target": "mime"
-            },
-            {
-              "id": "multer 2.1.0",
-              "target": "build_script_build"
-            },
-            {
-              "id": "spin 0.9.8",
-              "target": "spin"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.1.0"
-      },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "version_check 0.9.4",
-              "target": "version_check"
-            }
-          ],
-          "selects": {}
-        }
       },
       "license": "MIT"
     },
@@ -12004,52 +11863,6 @@
       },
       "license": "Apache-2.0"
     },
-    "qoi 0.4.1": {
-      "name": "qoi",
-      "version": "0.4.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/qoi/0.4.1/download",
-          "sha256": "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "qoi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "qoi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "bytemuck 1.14.0",
-              "target": "bytemuck"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.1"
-      },
-      "license": "MIT/Apache-2.0"
-    },
     "quote 1.0.35": {
       "name": "quote",
       "version": "1.0.35",
@@ -13091,6 +12904,53 @@
       },
       "license": null
     },
+    "rust-argon2 2.1.0": {
+      "name": "rust-argon2",
+      "version": "2.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rust-argon2/2.1.0/download",
+          "sha256": "9d9848531d60c9cbbcf9d166c885316c24bc0e2a9d3eba0956bb6cbbd79bc6e8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "argon2",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "argon2",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "base64 0.21.7",
+              "target": "base64"
+            },
+            {
+              "id": "blake2b_simd 1.0.2",
+              "target": "blake2b_simd"
+            },
+            {
+              "id": "constant_time_eq 0.3.0",
+              "target": "constant_time_eq"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "2.1.0"
+      },
+      "license": "MIT/Apache-2.0"
+    },
     "rustc-demangle 0.1.23": {
       "name": "rustc-demangle",
       "version": "0.1.23",
@@ -13311,20 +13171,6 @@
               "termios",
               "time"
             ],
-            "aarch64-unknown-nixos-gnu": [
-              "event",
-              "pipe",
-              "process",
-              "termios",
-              "time"
-            ],
-            "aarch64-unknown-nto-qnx710": [
-              "event",
-              "pipe",
-              "process",
-              "termios",
-              "time"
-            ],
             "arm-unknown-linux-gnueabi": [
               "event",
               "pipe",
@@ -13445,13 +13291,6 @@
               "termios",
               "time"
             ],
-            "x86_64-unknown-nixos-gnu": [
-              "event",
-              "pipe",
-              "process",
-              "termios",
-              "time"
-            ],
             "x86_64-unknown-none": [
               "termios"
             ]
@@ -13476,6 +13315,11 @@
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
+              {
+                "id": "errno 0.3.8",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
               {
                 "id": "linux-raw-sys 0.4.12",
                 "target": "linux_raw_sys"
@@ -16053,54 +15897,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "tiff 0.9.0": {
-      "name": "tiff",
-      "version": "0.9.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/tiff/0.9.0/download",
-          "sha256": "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tiff",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tiff",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "flate2 1.0.28",
-              "target": "flate2"
-            },
-            {
-              "id": "jpeg-decoder 0.3.0",
-              "target": "jpeg_decoder",
-              "alias": "jpeg"
-            },
-            {
-              "id": "weezl 0.1.7",
-              "target": "weezl"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.9.0"
-      },
-      "license": "MIT"
-    },
     "time 0.3.31": {
       "name": "time",
       "version": "0.3.31",
@@ -16667,66 +16463,6 @@
         },
         "edition": "2021",
         "version": "0.1.14"
-      },
-      "license": "MIT"
-    },
-    "tokio-tungstenite 0.20.1": {
-      "name": "tokio-tungstenite",
-      "version": "0.20.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-tungstenite/0.20.1/download",
-          "sha256": "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tokio_tungstenite",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tokio_tungstenite",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "connect",
-            "default",
-            "handshake",
-            "stream"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "futures-util 0.3.30",
-              "target": "futures_util"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "tokio 1.36.0",
-              "target": "tokio"
-            },
-            {
-              "id": "tungstenite 0.20.1",
-              "target": "tungstenite"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.20.1"
       },
       "license": "MIT"
     },
@@ -17479,96 +17215,6 @@
       },
       "license": "MIT"
     },
-    "tungstenite 0.20.1": {
-      "name": "tungstenite",
-      "version": "0.20.1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/tungstenite/0.20.1/download",
-          "sha256": "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "tungstenite",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "tungstenite",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "data-encoding",
-            "handshake",
-            "http",
-            "httparse",
-            "sha1",
-            "url"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "byteorder 1.5.0",
-              "target": "byteorder"
-            },
-            {
-              "id": "bytes 1.5.0",
-              "target": "bytes"
-            },
-            {
-              "id": "data-encoding 2.5.0",
-              "target": "data_encoding"
-            },
-            {
-              "id": "http 0.2.11",
-              "target": "http"
-            },
-            {
-              "id": "httparse 1.8.0",
-              "target": "httparse"
-            },
-            {
-              "id": "log 0.4.20",
-              "target": "log"
-            },
-            {
-              "id": "rand 0.8.5",
-              "target": "rand"
-            },
-            {
-              "id": "sha1 0.10.6",
-              "target": "sha1"
-            },
-            {
-              "id": "thiserror 1.0.56",
-              "target": "thiserror"
-            },
-            {
-              "id": "url 2.5.0",
-              "target": "url"
-            },
-            {
-              "id": "utf-8 0.7.6",
-              "target": "utf8"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.20.1"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "twox-hash 1.6.3": {
       "name": "twox-hash",
       "version": "1.6.3",
@@ -17994,36 +17640,6 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "utf-8 0.7.6": {
-      "name": "utf-8",
-      "version": "0.7.6",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/utf-8/0.7.6/download",
-          "sha256": "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "utf8",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "utf8",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2015",
-        "version": "0.7.6"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
     "uuid 1.7.0": {
       "name": "uuid",
       "version": "1.7.0",
@@ -18272,16 +17888,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "default",
-            "multer",
-            "multipart",
-            "tokio-tungstenite",
-            "websocket"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -18321,10 +17927,6 @@
               "target": "mime_guess"
             },
             {
-              "id": "multer 2.1.0",
-              "target": "multer"
-            },
-            {
               "id": "percent-encoding 2.3.1",
               "target": "percent_encoding"
             },
@@ -18359,10 +17961,6 @@
             {
               "id": "tokio-stream 0.1.14",
               "target": "tokio_stream"
-            },
-            {
-              "id": "tokio-tungstenite 0.20.1",
-              "target": "tokio_tungstenite"
             },
             {
               "id": "tokio-util 0.7.10",
@@ -18930,44 +18528,6 @@
         },
         "edition": "2018",
         "version": "0.3.67"
-      },
-      "license": "MIT OR Apache-2.0"
-    },
-    "weezl 0.1.7": {
-      "name": "weezl",
-      "version": "0.1.7",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/weezl/0.1.7/download",
-          "sha256": "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "weezl",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "weezl",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.1.7"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -20447,52 +20007,6 @@
         "version": "0.5.2"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "zune-inflate 0.2.54": {
-      "name": "zune-inflate",
-      "version": "0.2.54",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/zune-inflate/0.2.54/download",
-          "sha256": "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "zune_inflate",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "zune_inflate",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "simd-adler32",
-            "zlib"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "simd-adler32 0.3.7",
-              "target": "simd_adler32"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.54"
-      },
-      "license": "MIT OR Apache-2.0 OR Zlib"
     }
   },
   "binary_crates": [],
@@ -20525,12 +20039,6 @@
     "aarch64-unknown-linux-gnu": [
       "aarch64-unknown-linux-gnu"
     ],
-    "aarch64-unknown-nixos-gnu": [
-      "aarch64-unknown-nixos-gnu"
-    ],
-    "aarch64-unknown-nto-qnx710": [
-      "aarch64-unknown-nto-qnx710"
-    ],
     "arm-unknown-linux-gnueabi": [
       "arm-unknown-linux-gnueabi"
     ],
@@ -20562,28 +20070,23 @@
     "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(target_arch = \"aarch64\", target_arch = \"arm\")))": [
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-unknown-linux-gnueabi",
       "i686-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
       "arm-unknown-linux-gnueabi",
       "armv7-unknown-linux-gnueabi",
       "i686-unknown-linux-gnu",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\"))))))))": [
       "aarch64-apple-darwin",
@@ -20591,7 +20094,6 @@
       "aarch64-apple-ios-sim",
       "aarch64-fuchsia",
       "aarch64-linux-android",
-      "aarch64-unknown-nto-qnx710",
       "armv7-linux-androideabi",
       "i686-apple-darwin",
       "i686-linux-android",
@@ -20617,7 +20119,6 @@
       "aarch64-apple-ios-sim",
       "aarch64-fuchsia",
       "aarch64-linux-android",
-      "aarch64-unknown-nto-qnx710",
       "armv7-linux-androideabi",
       "i686-apple-darwin",
       "i686-linux-android",
@@ -20641,8 +20142,7 @@
       "aarch64-pc-windows-msvc"
     ],
     "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
-      "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu"
+      "aarch64-unknown-linux-gnu"
     ],
     "cfg(all(target_arch = \"aarch64\", target_os = \"windows\"))": [
       "aarch64-pc-windows-msvc"
@@ -20666,8 +20166,7 @@
       "i686-pc-windows-msvc"
     ],
     "cfg(all(target_arch = \"x86_64\", target_env = \"gnu\", not(target_abi = \"llvm\"), not(windows_raw_dylib)))": [
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
@@ -20678,8 +20177,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20692,8 +20189,7 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"arm\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
       "aarch64-apple-darwin",
@@ -20703,8 +20199,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20722,7 +20216,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86\", target_arch = \"x86_64\"))": [
@@ -20733,8 +20226,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "i686-apple-darwin",
       "i686-linux-android",
       "i686-pc-windows-msvc",
@@ -20747,7 +20238,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
@@ -20758,8 +20248,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "i686-apple-darwin",
       "i686-linux-android",
       "i686-pc-windows-msvc",
@@ -20772,7 +20260,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(any(target_os = \"macos\", target_os = \"ios\"))": [
@@ -20790,8 +20277,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20806,8 +20291,7 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(unix, target_os = \"wasi\"))": [
       "aarch64-apple-darwin",
@@ -20816,8 +20300,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20833,8 +20315,7 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(any(windows, unix, target_os = \"redox\"))": [
       "aarch64-apple-darwin",
@@ -20844,8 +20325,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20862,8 +20341,7 @@
       "x86_64-linux-android",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
       "aarch64-apple-darwin",
@@ -20872,8 +20350,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20895,15 +20371,12 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(any(target_os = \"windows\", target_os = \"macos\", target_os = \"ios\")))": [
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20922,7 +20395,6 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
@@ -20932,8 +20404,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20954,7 +20424,6 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(target_arch = \"wasm32\"))": [
@@ -20965,8 +20434,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -20988,7 +20455,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(target_family = \"wasm\"))": [
@@ -20999,8 +20465,6 @@
       "aarch64-linux-android",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21022,7 +20486,6 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
     "cfg(not(windows))": [
@@ -21032,8 +20495,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21055,10 +20516,8 @@
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu",
       "x86_64-unknown-none"
     ],
-    "cfg(target_arch = \"spirv\")": [],
     "cfg(target_arch = \"wasm32\")": [
       "wasm32-unknown-unknown",
       "wasm32-wasi"
@@ -21094,8 +20553,6 @@
       "aarch64-fuchsia",
       "aarch64-linux-android",
       "aarch64-unknown-linux-gnu",
-      "aarch64-unknown-nixos-gnu",
-      "aarch64-unknown-nto-qnx710",
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
       "armv7-unknown-linux-gnueabi",
@@ -21110,8 +20567,7 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-unknown-freebsd",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
+      "x86_64-unknown-linux-gnu"
     ],
     "cfg(windows)": [
       "aarch64-pc-windows-msvc",
@@ -21181,48 +20637,8 @@
     "x86_64-unknown-linux-gnu": [
       "x86_64-unknown-linux-gnu"
     ],
-    "x86_64-unknown-nixos-gnu": [
-      "x86_64-unknown-nixos-gnu"
-    ],
     "x86_64-unknown-none": [
       "x86_64-unknown-none"
     ]
-  },
-  "direct_deps": [
-    "anyhow 1.0.79",
-    "async-trait 0.1.77",
-    "chrono 0.4.33",
-    "cloudinary 0.4.0",
-    "fast_image_resize 3.0.2",
-    "fern 0.6.2",
-    "futures-executor 0.3.30",
-    "hex 0.4.3",
-    "image 0.24.8",
-    "isolang 2.4.0",
-    "jsonwebtoken 9.2.0",
-    "kafka 0.10.0",
-    "lapin 2.3.1",
-    "lazy_static 1.4.0",
-    "log 0.4.20",
-    "memcache 0.17.2",
-    "prost 0.12.3",
-    "prost-types 0.12.3",
-    "r2d2 0.8.10",
-    "regex-lite 0.1.5",
-    "reqwest 0.11.24",
-    "scylla 0.12.0",
-    "serde 1.0.196",
-    "serde_json 1.0.113",
-    "serde_yaml 0.9.31",
-    "tempfile 3.10.0",
-    "tokio 1.36.0",
-    "tonic 0.10.2",
-    "tonic-build 0.10.2",
-    "totp-lite 2.0.1",
-    "uuid 1.7.0",
-    "warp 0.3.6"
-  ],
-  "direct_dev_deps": [
-    "criterion 0.5.1"
-  ]
+  }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,12 +412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,7 +560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half 1.8.2",
+ "half",
 ]
 
 [[package]]
@@ -770,12 +764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto"
 version = "0.1.0"
 dependencies = [
@@ -847,12 +835,6 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "db"
@@ -982,22 +964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a1052dd43212a7777ec6a69b117da52f5e52f07aec47d00c1a2b33b85d06b08"
 dependencies = [
  "async-trait",
-]
-
-[[package]]
-name = "exr"
-version = "1.71.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832a761f35ab3e6664babfbdc6cef35a4860e816ec3916dcfd0882954e98a8a8"
-dependencies = [
- "bit_field",
- "flume 0.11.0",
- "half 2.2.1",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
 ]
 
 [[package]]
@@ -1266,16 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,15 +1261,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "half"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1533,13 +1480,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "exr",
- "gif",
  "jpeg-decoder",
  "num-traits",
  "png",
- "qoi",
- "tiff",
 ]
 
 [[package]]
@@ -1670,9 +1613,6 @@ name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"
@@ -1711,7 +1651,6 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "ref_slice",
- "snap",
  "thiserror",
  "tracing",
  "twox-hash",
@@ -1744,12 +1683,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -1873,24 +1806,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "multer"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -2514,15 +2429,6 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "quote"
@@ -3272,17 +3178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
-]
-
-[[package]]
 name = "time"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,18 +3288,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
 ]
 
 [[package]]
@@ -3589,25 +3472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,12 +3554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3756,7 +3614,6 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multer",
  "percent-encoding",
  "pin-project",
  "rustls-pemfile",
@@ -3766,7 +3623,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -3866,12 +3722,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "which"
@@ -4147,12 +3997,3 @@ name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,8 +785,7 @@ dependencies = [
  "fpe",
  "hex",
  "log",
- "rand",
- "regex",
+ "regex-lite",
  "ring",
  "rust-argon2",
 ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,7 +39,7 @@ load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencie
 
 crate_universe_dependencies()
 
-load("@rules_rust//crate_universe:defs.bzl", "crate", "crates_repository")
+load("@rules_rust//crate_universe:defs.bzl", "crates_repository")
 
 crates_repository(
     name = "crate_index",

--- a/autha/BUILD.bazel
+++ b/autha/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
-load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
-load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/autha/Cargo.toml
+++ b/autha/Cargo.toml
@@ -1,45 +1,37 @@
-[package]
-name = "autha"
+[workspace]
+resolver = "2"
+members = [
+    "autha",
+    "crypto",
+    "db",
+    "image_processor",
+]
+
+[workspace.package]
 version = "3.0.0"
+description = "fast and safe authorization delegation and account management API"
+homepage = "https://account.gravitalia.com"
+readme = "README.md"
 edition = "2021"
+license = "MPL"
 
-[dependencies]
-serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.10", features = [ "default" ] }
-tokio = { version = "1.36", features = ["rt-multi-thread"] }
-warp = "0.3"
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = false
+debug = false
 
-crypto = { path = "../crypto" }
-db = { path = "../db", features = ["logging", "cassandra", "memcached", "apache_kafka", "rabbitmq"] }
-image_processor = { path = "../image_processor" }
+[profile.dev]
+opt-level = "z"
+debug = true
 
-anyhow = "1"
-hex = "0.4"
-jsonwebtoken = "9.2"
-lazy_static = "1"
-prost = "0.12"
-prost-types = "0.12"
-regex-lite = "0"
-reqwest = { version = "0.11", features = ["json"] }
-serde_json = "1"
-serde_yaml = "0.9"
-totp-lite = "2"
-uuid = { version = "1.7", features = ["v4"] }
-isolang = { version = "2.4", features = ["list_languages"] }
-chrono = "0.4"
+[profile.dev.package.crypto]
+opt-level = 3
 
-fern = "0.6"
-log = "0.4"
+[profile.bench.package.crypto]
+opt-level = 3
 
-opentelemetry = { version = "0.21", optional = true }
-opentelemetry-otlp = { version = "0.14", features = ["tonic"], optional = true }
-opentelemetry_sdk =  { version = "0.21", features = ["rt-tokio"], optional = true }
-prometheus = { version = "0.13", features = ["process"], optional = true }
-
-[build-dependencies]
-tonic-build = { version = "0.10", features = [ "prost" ] }
-
-[features]
-kafka = ["db/apache_kafka"]
-rabbitmq = ["db/rabbitmq"]
-telemetry = ["opentelemetry", "opentelemetry-otlp", "opentelemetry_sdk", "prometheus"]
+[profile.release.package.image_processor]
+opt-level = "z"

--- a/autha/Cargo.toml
+++ b/autha/Cargo.toml
@@ -1,37 +1,45 @@
-[workspace]
-resolver = "2"
-members = [
-    "autha",
-    "crypto",
-    "db",
-    "image_processor",
-]
-
-[workspace.package]
+[package]
+name = "autha"
 version = "3.0.0"
-description = "fast and safe authorization delegation and account management API"
-homepage = "https://account.gravitalia.com"
-readme = "README.md"
 edition = "2021"
-license = "MPL"
 
-[profile.release]
-opt-level = 3
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = false
-debug = false
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+tonic = { version = "0.10", features = ["default"] }
+tokio = { version = "1.36", features = ["rt-multi-thread"] }
+warp = { version = "0.3", default-features = false }
 
-[profile.dev]
-opt-level = "z"
-debug = true
+crypto = { path = "../crypto", features = ["argon2", "format_preserving"] }
+db = { path = "../db", features = ["logging", "cassandra", "memcached", "apache_kafka", "rabbitmq"] }
+image_processor = { path = "../image_processor" }
 
-[profile.dev.package.crypto]
-opt-level = 3
+anyhow = "1"
+hex = "0.4"
+jsonwebtoken = "9.2"
+lazy_static = "1"
+prost = "0.12"
+prost-types = "0.12"
+regex-lite = "0"
+reqwest = { version = "0.11", features = ["json"] }
+serde_json = "1"
+serde_yaml = "0.9"
+totp-lite = "2"
+uuid = { version = "1.7", features = ["v4"] }
+isolang = { version = "2.4", features = ["list_languages"] }
+chrono = "0.4"
 
-[profile.bench.package.crypto]
-opt-level = 3
+fern = "0.6"
+log = "0.4"
 
-[profile.release.package.image_processor]
-opt-level = "z"
+opentelemetry = { version = "0.21", optional = true }
+opentelemetry-otlp = { version = "0.14", features = ["tonic"], optional = true }
+opentelemetry_sdk =  { version = "0.21", features = ["rt-tokio"], optional = true }
+prometheus = { version = "0.13", features = ["process"], optional = true }
+
+[build-dependencies]
+tonic-build = { version = "0.10", features = [ "prost" ] }
+
+[features]
+kafka = ["db/apache_kafka"]
+rabbitmq = ["db/rabbitmq"]
+telemetry = ["opentelemetry", "opentelemetry-otlp", "opentelemetry_sdk", "prometheus"]

--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -29,10 +29,10 @@ rust_test(
         "format_preserving",
     ],
     deps = all_crate_deps(
-        normal = True,
+        normal_dev = True,
     ),
     proc_macro_deps = all_crate_deps(
-        proc_macro = True,
+        proc_macro_dev = True,
     ),
     size = "large",
     timeout = "short",

--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -7,6 +7,10 @@ rust_library(
     name = "crypto",
     srcs = glob(["src/**/*.rs"]),
     aliases = aliases(),
+    crate_features = [
+        "argon2",
+        "format_preserving",
+    ],
     deps = all_crate_deps(
         normal = True,
     ),
@@ -20,6 +24,10 @@ rust_library(
 rust_test(
     name = "crypto_test",
     crate = ":crypto",
+    crate_features = [
+        "argon2",
+        "format_preserving",
+    ],
     deps = all_crate_deps(
         normal = True,
     ),

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -9,8 +9,7 @@ aes = { version = "0.8", optional = true }
 fpe = { version = "0.6", optional = true }
 hex = "0"
 log = { version = "0.4", optional = true }
-rand = { version = "0.8", optional = true }
-ring = { version = "0.17", optional = true }
+ring = "0.17"
 rust-argon2 = { version = "2", optional = true }
 
 [dev-dependencies]
@@ -18,14 +17,9 @@ criterion = { version = "0.5", features = ["html_reports"] }
 regex-lite = "0.1"
 
 [features]
-logging = ["log"]
-chacha20 = ["ring", "rand"]
-format_preserving = ["aes", "fpe"]
 argon2 = ["rust-argon2"]
-sha = ["ring"]
-
-encryption = ["dep:chacha20", "dep:format_preserving"]
-hashing = ["dep:argon2", "dep:sha"]
+format_preserving = ["aes", "fpe"]
+logging = ["log"]
 
 [[bench]]
 name = "hash_benchmark"
@@ -33,4 +27,8 @@ harness = false
 
 [[bench]]
 name = "encryption_benchmark"
+harness = false
+
+[[bench]]
+name = "random_benchmark"
 harness = false

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -10,12 +10,12 @@ fpe = { version = "0.6", optional = true }
 hex = "0"
 log = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
-regex = "1"
 ring = { version = "0.17", optional = true }
 rust-argon2 = { version = "2", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+regex-lite = "0.1"
 
 [features]
 logging = ["log"]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -5,17 +5,27 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-aes = "0.8"
-fpe = "0.6"
+aes = { version = "0.8", optional = true }
+fpe = { version = "0.6", optional = true }
 hex = "0"
-log = "0.4"
-rand = "0.8"
+log = { version = "0.4", optional = true }
+rand = { version = "0.8", optional = true }
 regex = "1"
-ring = "0.17"
-rust-argon2 = "2"
+ring = { version = "0.17", optional = true }
+rust-argon2 = { version = "2", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+
+[features]
+logging = ["log"]
+chacha20 = ["ring", "rand"]
+format_preserving = ["aes", "fpe"]
+argon2 = ["rust-argon2"]
+sha = ["ring"]
+
+encryption = ["dep:chacha20", "dep:format_preserving"]
+hashing = ["dep:argon2", "dep:sha"]
 
 [[bench]]
 name = "hash_benchmark"

--- a/crypto/benches/hash_benchmark.rs
+++ b/crypto/benches/hash_benchmark.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use crypto::hash::*;
 
 fn hash_benchmark(c: &mut Criterion) {
-    c.bench_function("hash", |b| {
+    c.bench_function("argon2id", |b| {
         b.iter(|| argon2("password".as_bytes(), b"test"))
     });
 }
@@ -10,14 +10,18 @@ fn hash_benchmark(c: &mut Criterion) {
 fn sha256_digest_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput");
     group.throughput(Throughput::Bytes(32));
-    group.bench_function("sha256_digest", |b| b.iter(|| sha256(b"Internet Protocol")));
+    group.bench_function("sha256_digest", |b| {
+        b.iter(|| sha256(b"Internet Protocol"))
+    });
     group.finish();
 }
 
 fn sha1_digest_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("throughput");
     group.throughput(Throughput::Bytes(20));
-    group.bench_function("sha1_digest", |b| b.iter(|| sha1(b"Internet Protocol")));
+    group.bench_function("sha1_digest", |b| {
+        b.iter(|| sha1(b"Internet Protocol"))
+    });
     group.finish();
 }
 

--- a/crypto/benches/random_benchmark.rs
+++ b/crypto/benches/random_benchmark.rs
@@ -1,0 +1,20 @@
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use crypto::{random_bytes, random_string};
+
+fn random_bytes_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("throughput");
+    group.throughput(Throughput::Bytes(200));
+    group.bench_function("random_bytes 200", |b| b.iter(|| random_bytes(200)));
+    group.finish();
+}
+
+fn random_string_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("throughput");
+    group.throughput(Throughput::Bytes(200));
+    group
+        .bench_function("random_string 200", |b| b.iter(|| random_string(200)));
+    group.finish();
+}
+
+criterion_group!(benches, random_bytes_benchmark, random_string_benchmark,);
+criterion_main!(benches);

--- a/crypto/src/decrypt.rs
+++ b/crypto/src/decrypt.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+#[cfg(feature = "format_preserving")]
 use fpe::ff1::{FlexibleNumeralString, Operations, FF1};
 use ring::aead::*;
 
@@ -25,22 +26,26 @@ pub fn chacha20_poly1305(
     match opening_key.open_in_place(Aad::empty(), &mut data) {
         Ok(res) => String::from_utf8(res.to_vec()),
         Err(_) => {
+            #[cfg(feature = "logging")]
             log::error!(
                 "Cannot decrypt ChaCha20-Poly1205 data, got an error during opening. Have you decoded hex before call the function?"
             );
 
             Ok("".to_string())
-        }
+        },
     }
 }
 
 /// Decrypts the provided data using the Format-preserving encryption
 /// with FF1 and AES256.
+#[cfg(feature = "format_preserving")]
 pub fn format_preserving_encryption(data: Vec<u16>) -> Result<String> {
     // Get encryption key. The key MUST be 32 bytes (256 bits), otherwise it panics.
     let mut key = std::env::var("AES256_KEY").unwrap_or_default();
     if key.is_empty() {
-        key = "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233".to_string();
+        key =
+            "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233"
+                .to_string();
     }
 
     let length = data.len();

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
+#[cfg(feature = "argon2")]
 use argon2::{Config, Variant, Version};
 use ring::digest::{Context, SHA1_FOR_LEGACY_USE_ONLY, SHA256};
 
 /// Hash plaintext using Argon2, mostly used for passwords.
 /// It uses the two version, Argon2d for GPU attacks and Argon2i for auxiliary channel attacks.
+#[cfg(feature = "argon2")]
 pub fn argon2(data: &[u8], vanity: &[u8]) -> String {
     argon2::hash_encoded(
         data,
@@ -35,7 +37,12 @@ pub fn argon2(data: &[u8], vanity: &[u8]) -> String {
 
 /// Verify if provided hash is matching with the plaintext password.
 /// Using Argon2 to provide checking.
-pub fn check_argon2(hash: String, password: &[u8], vanity: &[u8]) -> Result<bool> {
+#[cfg(feature = "argon2")]
+pub fn check_argon2(
+    hash: String,
+    password: &[u8],
+    vanity: &[u8],
+) -> Result<bool> {
     Ok(argon2::verify_encoded_ext(
         &hash,
         password,
@@ -70,9 +77,11 @@ pub fn sha1(data: &[u8]) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "argon2")]
     use regex_lite::Regex;
 
     #[test]
+    #[cfg(feature = "argon2")]
     fn test_argon2() {
         let pwd = argon2(b"password", b"test");
         assert!(Regex::new(
@@ -89,7 +98,8 @@ mod tests {
 
         assert_eq!(
             hash.unwrap(),
-            "8fced00b6ce281456d69daef5f2b33eaf1a4a29b5923ebe5f1f2c54f5886c7a3".to_string()
+            "8fced00b6ce281456d69daef5f2b33eaf1a4a29b5923ebe5f1f2c54f5886c7a3"
+                .to_string()
         );
     }
 

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -70,11 +70,12 @@ pub fn sha1(data: &[u8]) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use regex_lite::Regex;
 
     #[test]
     fn test_argon2() {
         let pwd = argon2(b"password", b"test");
-        assert!(regex::Regex::new(
+        assert!(Regex::new(
             r"[$]argon2(i)?(d)?[$]v=[0-9]{1,2}[$]m=[0-9]+,t=[0-9]{1,},p=[0-9]{1,}[$].*"
         )
         .unwrap()

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -39,13 +39,14 @@ pub fn random_string(length: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use regex_lite::Regex;
 
     #[test]
     fn test_random_string() {
         let str = random_string(20);
         assert_eq!(str.len(), 20);
         assert_eq!(
-            regex::Regex::new(
+            Regex::new(
                 r"[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_%?!&]*"
             )
             .unwrap()

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -11,7 +11,7 @@ log = { version = "0.4", optional = true }
 r2d2 = "0.8"
 memcache = { version = "0.17", optional = true }
 scylla = { version = "0.12", optional = true }
-kafka = { version = "0.10", optional = true }
+kafka = { version = "0.10", default-features = false, features = ["gzip", "security"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 futures-executor = { version = "0", optional = true }
 

--- a/image_processor/Cargo.toml
+++ b/image_processor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-image = "0.24"
+image = { version = "0.24", default-features = false, features = ["jpeg", "png", "webp"] }
 fast_image_resize = "3.0"
 tempfile = "3.10.0"
 


### PR DESCRIPTION
This PR aims to reduce `crypto` library size to also
reduce binary size after compiling. But it also aims
to create features to disable useless features on
certain binary.

- [x] use `regex-lite`
- [x] use rand from `ring`
- [x] add features

Close #320.