### PR TITLE
chore: remove anyhow from `crypto`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "1dabc375a8e628bb7cb22fd4df4dd6b6563409e0709332251d8cfdfd43e157c9",
+  "checksum": "e4d500998102afde3d8349d454fc3c0a003e16a48f65fa9e0b076fbf0d1bd487",
   "crates": {
     "addr2line 0.21.0": {
       "name": "addr2line",
@@ -3840,10 +3840,6 @@
             {
               "id": "aes 0.8.3",
               "target": "aes"
-            },
-            {
-              "id": "anyhow 1.0.79",
-              "target": "anyhow"
             },
             {
               "id": "fpe 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,11 +768,9 @@ name = "crypto"
 version = "0.1.0"
 dependencies = [
  "aes",
- "anyhow",
  "criterion",
  "fpe",
  "hex",
- "log",
  "regex-lite",
  "ring",
  "rust-argon2",

--- a/autha/src/router/create.rs
+++ b/autha/src/router/create.rs
@@ -86,7 +86,7 @@ pub async fn handle(
     }
 
     // Check if user have already created account 5 minutes ago.
-    let hashed_ip = crypto::hash::sha256(ip.as_bytes()).unwrap_or_default();
+    let hashed_ip = crypto::hash::sha256(ip.as_bytes());
     if hashed_ip.is_empty() {
         log::warn!(
             "The IP could not be hashed. This can result in the uncontrolled creation of accounts."
@@ -250,7 +250,7 @@ pub async fn handle(
                     &crypto::hash::argon2(
                         body.password.as_bytes(),
                         body.vanity.as_bytes(),
-                    ),
+                    )?,
                     &body.locale,
                     &phone.unwrap_or_default(), // Never insert directly a null value, otherwhise it will create a tombestone.
                     &birthdate.unwrap_or_default(), // Never insert directly a null value, otherwhise it will create a tombestone.

--- a/autha/src/router/login.rs
+++ b/autha/src/router/login.rs
@@ -26,7 +26,7 @@ pub async fn handle(
     }
 
     // Check that the user has not tried to connect 5 times in the last 5 minutes.
-    let hashed_ip = crypto::hash::sha256(ip.as_bytes()).unwrap_or_default();
+    let hashed_ip = crypto::hash::sha256(ip.as_bytes());
     let rate_limit = if hashed_ip.is_empty() {
         log::warn!("The IP could not be hashed. This can result in massive trying of connection.");
 

--- a/autha/src/router/users.rs
+++ b/autha/src/router/users.rs
@@ -344,11 +344,33 @@ pub async fn update(
         if !is_psw_valid || !crate::router::create::PASSWORD.is_match(&np) {
             return Ok(crate::router::err(super::INVALID_PASSWORD));
         } else {
+            let argon_config = crypto::hash::Argon2Configuration {
+                memory_cost: std::env::var("MEMORY_COST")
+                    .unwrap_or_default()
+                    .parse::<u32>()
+                    .unwrap_or(262144),
+                round: std::env::var("ROUND")
+                    .unwrap_or_default()
+                    .parse::<u32>()
+                    .unwrap_or(1),
+                lanes: 8,
+                secret: std::env::var("KEY")
+                    .unwrap_or_else(|_| "KEY".to_string()),
+                hash_length: std::env::var("HASH_LENGTH")
+                    .unwrap_or_default()
+                    .parse::<u32>()
+                    .unwrap_or(16),
+            };
+
             batch.append_statement(
                 "UPDATE accounts.users SET password = ? WHERE vanity = ?",
             );
             batch_values.push((
-                crypto::hash::argon2(np.as_bytes(), vanity.as_bytes())?,
+                crypto::hash::argon2(
+                    argon_config,
+                    np.as_bytes(),
+                    Some(vanity.as_bytes()),
+                )?,
                 vanity.clone(),
             ));
         }

--- a/autha/src/router/users.rs
+++ b/autha/src/router/users.rs
@@ -348,7 +348,7 @@ pub async fn update(
                 "UPDATE accounts.users SET password = ? WHERE vanity = ?",
             );
             batch_values.push((
-                crypto::hash::argon2(np.as_bytes(), vanity.as_bytes()),
+                crypto::hash::argon2(np.as_bytes(), vanity.as_bytes())?,
                 vanity.clone(),
             ));
         }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -4,11 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
 aes = { version = "0.8", optional = true }
 fpe = { version = "0.6", optional = true }
 hex = "0"
-log = { version = "0.4", optional = true }
 ring = "0.17"
 rust-argon2 = { version = "2", optional = true }
 
@@ -19,7 +17,6 @@ regex-lite = "0.1"
 [features]
 argon2 = ["rust-argon2"]
 format_preserving = ["aes", "fpe"]
-logging = ["log"]
 
 [[bench]]
 name = "hash_benchmark"

--- a/crypto/benches/hash_benchmark.rs
+++ b/crypto/benches/hash_benchmark.rs
@@ -6,7 +6,7 @@ fn hash_benchmark(c: &mut Criterion) {
         memory_cost: 262144,
         round: 1,
         lanes: 8,
-        secret: "".to_string(),
+        secret: "KEY".to_string(),
         hash_length: 16,
     };
 

--- a/crypto/benches/hash_benchmark.rs
+++ b/crypto/benches/hash_benchmark.rs
@@ -2,8 +2,16 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use crypto::hash::*;
 
 fn hash_benchmark(c: &mut Criterion) {
+    let config = Argon2Configuration {
+        memory_cost: 262144,
+        round: 1,
+        lanes: 8,
+        secret: "".to_string(),
+        hash_length: 16,
+    };
+
     c.bench_function("argon2id", |b| {
-        b.iter(|| argon2("password".as_bytes(), b"test"))
+        b.iter(|| argon2(config.clone(), "password".as_bytes(), Some(b"test")))
     });
 }
 

--- a/crypto/src/decrypt.rs
+++ b/crypto/src/decrypt.rs
@@ -1,14 +1,14 @@
-use anyhow::Result;
 #[cfg(feature = "format_preserving")]
 use fpe::ff1::{FlexibleNumeralString, Operations, FF1};
 use ring::aead::*;
+use crate::{CryptoError, RADIX};
 
 /// Decrypts the provided data using the CHACHA20_POLY1305 algorithm.
 /// Returns the decrypted data as a string, or default string if decryption fails.
 pub fn chacha20_poly1305(
     nonce: [u8; 12],
     mut data: Vec<u8>,
-) -> Result<String, std::string::FromUtf8Error> {
+) -> Result<String, CryptoError> {
     // Get CHACHA20 key. The key MUST be 32 bytes (256 bits), otherwise it panics.
     let key = std::env::var("CHACHA20_KEY").unwrap_or_default();
     let key_bytes: &[u8] = if key.is_empty() {
@@ -17,42 +17,38 @@ pub fn chacha20_poly1305(
         key.as_bytes()
     };
 
-    let mut opening_key = {
-        let key = UnboundKey::new(&CHACHA20_POLY1305, key_bytes).unwrap();
-        let nonce_gen = crate::encrypt::NonceGen::new(nonce);
-        OpeningKey::new(key, nonce_gen)
+    let mut opening_key = match UnboundKey::new(&CHACHA20_POLY1305, key_bytes) {
+        Ok(key) => {
+            let nonce_gen = crate::encrypt::NonceGen::new(nonce);
+            OpeningKey::new(key, nonce_gen)
+        }
+        Err(_) => return Err(CryptoError::Unspecified),
     };
 
     match opening_key.open_in_place(Aad::empty(), &mut data) {
-        Ok(res) => String::from_utf8(res.to_vec()),
-        Err(_) => {
-            #[cfg(feature = "logging")]
-            log::error!(
-                "Cannot decrypt ChaCha20-Poly1205 data, got an error during opening. Have you decoded hex before call the function?"
-            );
-
-            Ok("".to_string())
-        },
+        Ok(res) => {
+            String::from_utf8(res.to_vec()).map_err(|_| CryptoError::UTF8Error)
+        }
+        Err(_) => Err(CryptoError::Unspecified),
     }
 }
 
 /// Decrypts the provided data using the Format-preserving encryption
 /// with FF1 and AES256.
 #[cfg(feature = "format_preserving")]
-pub fn format_preserving_encryption(data: Vec<u16>) -> Result<String> {
+pub fn format_preserving_encryption(data: Vec<u16>) -> Result<String, CryptoError> {
     // Get encryption key. The key MUST be 32 bytes (256 bits), otherwise it panics.
-    let mut key = std::env::var("AES256_KEY").unwrap_or_default();
-    if key.is_empty() {
-        key =
-            "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233"
-                .to_string();
-    }
+    let key = std::env::var("AES256_KEY").unwrap_or_else(|_| {
+        "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233".to_string()
+    });
 
-    let length = data.len();
+    let key_bytes = hex::decode(&key).map_err(|_| CryptoError::UnableDecodeHex)?;
 
-    let ff = FF1::<aes::Aes256>::new(&hex::decode(key)?, 256)?;
+    let ff = FF1::<aes::Aes256>::new(&key_bytes, RADIX)
+        .map_err(|_| CryptoError::InvalidRadix)?;
 
-    let decrypt = ff.decrypt(&[], &FlexibleNumeralString::from(data))?;
+    let decrypt = ff.decrypt(&[], &FlexibleNumeralString::from(data.clone()))
+        .map_err(|_| CryptoError::ExceedRadix)?;
 
-    Ok(String::from_utf8_lossy(&decrypt.to_be_bytes(256, length)).to_string())
+    Ok(decrypt.to_be_bytes(RADIX, data.len()).iter().map(|&b| b as char).collect())
 }

--- a/crypto/src/decrypt.rs
+++ b/crypto/src/decrypt.rs
@@ -1,7 +1,7 @@
+use crate::{CryptoError, RADIX};
 #[cfg(feature = "format_preserving")]
 use fpe::ff1::{FlexibleNumeralString, Operations, FF1};
 use ring::aead::*;
-use crate::{CryptoError, RADIX};
 
 /// Decrypts the provided data using the CHACHA20_POLY1305 algorithm.
 /// Returns the decrypted data as a string, or default string if decryption fails.
@@ -21,14 +21,14 @@ pub fn chacha20_poly1305(
         Ok(key) => {
             let nonce_gen = crate::encrypt::NonceGen::new(nonce);
             OpeningKey::new(key, nonce_gen)
-        }
+        },
         Err(_) => return Err(CryptoError::Unspecified),
     };
 
     match opening_key.open_in_place(Aad::empty(), &mut data) {
         Ok(res) => {
             String::from_utf8(res.to_vec()).map_err(|_| CryptoError::UTF8Error)
-        }
+        },
         Err(_) => Err(CryptoError::Unspecified),
     }
 }
@@ -36,19 +36,28 @@ pub fn chacha20_poly1305(
 /// Decrypts the provided data using the Format-preserving encryption
 /// with FF1 and AES256.
 #[cfg(feature = "format_preserving")]
-pub fn format_preserving_encryption(data: Vec<u16>) -> Result<String, CryptoError> {
+pub fn format_preserving_encryption(
+    data: Vec<u16>,
+) -> Result<String, CryptoError> {
     // Get encryption key. The key MUST be 32 bytes (256 bits), otherwise it panics.
     let key = std::env::var("AES256_KEY").unwrap_or_else(|_| {
-        "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233".to_string()
+        "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233"
+            .to_string()
     });
 
-    let key_bytes = hex::decode(&key).map_err(|_| CryptoError::UnableDecodeHex)?;
+    let key_bytes =
+        hex::decode(key).map_err(|_| CryptoError::UnableDecodeHex)?;
 
     let ff = FF1::<aes::Aes256>::new(&key_bytes, RADIX)
         .map_err(|_| CryptoError::InvalidRadix)?;
 
-    let decrypt = ff.decrypt(&[], &FlexibleNumeralString::from(data.clone()))
+    let decrypt = ff
+        .decrypt(&[], &FlexibleNumeralString::from(data.clone()))
         .map_err(|_| CryptoError::ExceedRadix)?;
 
-    Ok(decrypt.to_be_bytes(RADIX, data.len()).iter().map(|&b| b as char).collect())
+    Ok(decrypt
+        .to_be_bytes(RADIX, data.len())
+        .iter()
+        .map(|&b| b as char)
+        .collect())
 }

--- a/crypto/src/encrypt.rs
+++ b/crypto/src/encrypt.rs
@@ -1,4 +1,4 @@
-use crate::{CryptoError, RADIX, random_bytes};
+use crate::{random_bytes, CryptoError, RADIX};
 #[cfg(feature = "format_preserving")]
 use fpe::ff1::{FlexibleNumeralString, Operations, FF1};
 use ring::aead::*;
@@ -79,15 +79,18 @@ pub fn format_preserving_encryption(
 ) -> Result<String, CryptoError> {
     // Get encryption key. The key MUST be 32 bytes (256 bits), otherwise it panics.
     let key = std::env::var("AES256_KEY").unwrap_or_else(|_| {
-        "4D6a514749614D6c74595a50756956446e5673424142524c4f4451736c515233".to_string()
+        "4D6a514749614D6c74595a50756956446e5673424142524c4f4451736c515233"
+            .to_string()
     });
 
-    let key_bytes = hex::decode(&key).map_err(|_| CryptoError::UnableDecodeHex)?;
+    let key_bytes =
+        hex::decode(key).map_err(|_| CryptoError::UnableDecodeHex)?;
 
     let ff = FF1::<aes::Aes256>::new(&key_bytes, RADIX)
         .map_err(|_| CryptoError::InvalidRadix)?;
 
-    let encrypted_data = ff.encrypt(&[], &FlexibleNumeralString::from(data.clone()))
+    let encrypted_data = ff
+        .encrypt(&[], &FlexibleNumeralString::from(data.clone()))
         .map_err(|_| CryptoError::ExceedRadix)?;
 
     Ok(hex::encode(encrypted_data.to_be_bytes(RADIX, data.len())))

--- a/crypto/src/encrypt.rs
+++ b/crypto/src/encrypt.rs
@@ -1,8 +1,8 @@
-use crate::random_bytes;
-use anyhow::Result;
+use crate::{CryptoError, RADIX, random_bytes};
 #[cfg(feature = "format_preserving")]
 use fpe::ff1::{FlexibleNumeralString, Operations, FF1};
 use ring::aead::*;
+use ring::error::Unspecified;
 use std::num::Wrapping;
 
 /// A generator for producing nonces.
@@ -27,15 +27,16 @@ impl NonceGen {
 }
 
 impl NonceSequence for NonceGen {
-    fn advance(&mut self) -> Result<Nonce, ring::error::Unspecified> {
+    fn advance(&mut self) -> Result<Nonce, Unspecified> {
         // ! Warning: doesn't check u128 overflow correctly
         // Also, ring docs explicitly call this
         // out as "reasonable (but probably not ideal)"
         let n = self.current.0;
         self.current += 1;
         if self.current.0 == self.start {
-            return Err(ring::error::Unspecified);
+            return Err(Unspecified);
         }
+
         Ok(Nonce::assume_unique_for_key(
             n.to_le_bytes()[..12].try_into().unwrap_or_default(),
         ))
@@ -44,7 +45,9 @@ impl NonceSequence for NonceGen {
 
 /// Encrypts the provided data using the CHACHA20_POLY1305 algorithm.
 /// Returns a tuple containing the nonce as a hexadecimal string and the encrypted data as a hexadecimal string.
-pub fn chacha20_poly1305(mut data: Vec<u8>) -> Result<(String, String)> {
+pub fn chacha20_poly1305(
+    mut data: Vec<u8>,
+) -> Result<(String, String), Unspecified> {
     // Get CHACHA20 key. The key MUST be 32 bytes (256 bits), otherwise it panics.
     let key = std::env::var("CHACHA20_KEY").unwrap_or_default();
     let key_bytes: &[u8] = if key.is_empty() {
@@ -54,7 +57,8 @@ pub fn chacha20_poly1305(mut data: Vec<u8>) -> Result<(String, String)> {
     };
 
     // Generate crypto-secure 12 random bytes.
-    let nonce_seed: [u8; 12] = random_bytes(12).as_slice().try_into()?;
+    let nonce_seed: [u8; 12] =
+        random_bytes(12).as_slice().try_into().unwrap_or_default();
 
     let mut sealing_key = {
         let key = UnboundKey::new(&CHACHA20_POLY1305, key_bytes)?;
@@ -70,22 +74,23 @@ pub fn chacha20_poly1305(mut data: Vec<u8>) -> Result<(String, String)> {
 /// Encrypts data the provided data using (Format-preserving encryption)
 /// and FF1 (Feistel-based Encryption Mode) with AES256.
 #[cfg(feature = "format_preserving")]
-pub fn format_preserving_encryption(data: Vec<u16>) -> Result<String> {
+pub fn format_preserving_encryption(
+    data: Vec<u16>,
+) -> Result<String, CryptoError> {
     // Get encryption key. The key MUST be 32 bytes (256 bits), otherwise it panics.
-    let mut key = std::env::var("AES256_KEY").unwrap_or_default();
-    if key.is_empty() {
-        key =
-            "4D6A514749614D6C74595A50756956446E5673424142524C4F4451736C515233"
-                .to_string();
-    }
+    let key = std::env::var("AES256_KEY").unwrap_or_else(|_| {
+        "4D6a514749614D6c74595a50756956446e5673424142524c4f4451736c515233".to_string()
+    });
 
-    let length = data.len();
+    let key_bytes = hex::decode(&key).map_err(|_| CryptoError::UnableDecodeHex)?;
 
-    let ff = FF1::<aes::Aes256>::new(&hex::decode(key)?, 256)?;
-    Ok(hex::encode(
-        ff.encrypt(&[], &FlexibleNumeralString::from(data))?
-            .to_be_bytes(256, length),
-    ))
+    let ff = FF1::<aes::Aes256>::new(&key_bytes, RADIX)
+        .map_err(|_| CryptoError::InvalidRadix)?;
+
+    let encrypted_data = ff.encrypt(&[], &FlexibleNumeralString::from(data.clone()))
+        .map_err(|_| CryptoError::ExceedRadix)?;
+
+    Ok(hex::encode(encrypted_data.to_be_bytes(RADIX, data.len())))
 }
 
 #[cfg(test)]

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,12 +1,11 @@
-use anyhow::Result;
 #[cfg(feature = "argon2")]
-use argon2::{Config, Variant, Version};
+use argon2::{Config, Error, Variant, Version};
 use ring::digest::{Context, SHA1_FOR_LEGACY_USE_ONLY, SHA256};
 
 /// Hash plaintext using Argon2, mostly used for passwords.
 /// It uses the two version, Argon2d for GPU attacks and Argon2i for auxiliary channel attacks.
 #[cfg(feature = "argon2")]
-pub fn argon2(data: &[u8], vanity: &[u8]) -> String {
+pub fn argon2(data: &[u8], vanity: &[u8]) -> Result<String, Error> {
     argon2::hash_encoded(
         data,
         crate::random_string(16).as_bytes(),
@@ -32,7 +31,6 @@ pub fn argon2(data: &[u8], vanity: &[u8]) -> String {
                 .unwrap_or(16),
         },
     )
-    .unwrap()
 }
 
 /// Verify if provided hash is matching with the plaintext password.
@@ -42,36 +40,36 @@ pub fn check_argon2(
     hash: String,
     password: &[u8],
     vanity: &[u8],
-) -> Result<bool> {
-    Ok(argon2::verify_encoded_ext(
+) -> Result<bool, Error> {
+    argon2::verify_encoded_ext(
         &hash,
         password,
         std::env::var("KEY")
             .unwrap_or_else(|_| "KEY".to_string())
             .as_bytes(),
         vanity,
-    )?)
+    )
 }
 
 /// Compute the SHA256 digest for the bytes data.
-pub fn sha256(data: &[u8]) -> Result<String> {
+pub fn sha256(data: &[u8]) -> String {
     let mut context = Context::new(&SHA256);
 
     context.update(data);
 
-    Ok(hex::encode(context.finish()))
+    hex::encode(context.finish())
 }
 
 /// Compute the SHA1 digest for the bytes data.
 ///
 /// # Warning
 /// This should only be used when security is not a priority.
-pub fn sha1(data: &[u8]) -> Result<String> {
+pub fn sha1(data: &[u8]) -> String {
     let mut context = Context::new(&SHA1_FOR_LEGACY_USE_ONLY);
 
     context.update(data);
 
-    Ok(hex::encode(context.finish()))
+    hex::encode(context.finish())
 }
 
 #[cfg(test)]
@@ -83,7 +81,8 @@ mod tests {
     #[test]
     #[cfg(feature = "argon2")]
     fn test_argon2() {
-        let pwd = argon2(b"password", b"test");
+        let pwd = argon2(b"password", b"test").unwrap();
+
         assert!(Regex::new(
             r"[$]argon2(i)?(d)?[$]v=[0-9]{1,2}[$]m=[0-9]+,t=[0-9]{1,},p=[0-9]{1,}[$].*"
         )
@@ -97,7 +96,7 @@ mod tests {
         let hash = sha256(b"rainbow");
 
         assert_eq!(
-            hash.unwrap(),
+            hash,
             "8fced00b6ce281456d69daef5f2b33eaf1a4a29b5923ebe5f1f2c54f5886c7a3"
                 .to_string()
         );
@@ -108,7 +107,7 @@ mod tests {
         let hash = sha1(b"hello world!");
 
         assert_eq!(
-            hash.unwrap(),
+            hash,
             "430ce34d020724ed75a196dfc2ad67c77772d169".to_string()
         );
     }

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -93,7 +93,7 @@ mod tests {
             memory_cost: 262144,
             round: 1,
             lanes: 8,
-            secret: "".to_string(),
+            secret: "KEY".to_string(),
             hash_length: 16,
         };
 

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -2,33 +2,41 @@
 use argon2::{Config, Error, Variant, Version};
 use ring::digest::{Context, SHA1_FOR_LEGACY_USE_ONLY, SHA256};
 
+/// Configuration for Argon2id.
+#[derive(Default, Clone)]
+pub struct Argon2Configuration {
+    /// Amount of memory used in KB.
+    pub memory_cost: u32,
+    /// Higher is better, higher is slower.
+    pub round: u32,
+    /// Task parallelization. Usually half the number of your CPU cores.
+    pub lanes: u32,
+    /// Private key used for hashing.
+    pub secret: String,
+    /// Length of final hash. A higher hash may be longer, but more secure.
+    pub hash_length: u32,
+}
+
 /// Hash plaintext using Argon2, mostly used for passwords.
 /// It uses the two version, Argon2d for GPU attacks and Argon2i for auxiliary channel attacks.
 #[cfg(feature = "argon2")]
-pub fn argon2(data: &[u8], vanity: &[u8]) -> Result<String, Error> {
+pub fn argon2(
+    config: Argon2Configuration,
+    data: &[u8],
+    associated_data: Option<&[u8]>,
+) -> Result<String, Error> {
     argon2::hash_encoded(
         data,
         crate::random_string(16).as_bytes(),
         &Config {
             variant: Variant::Argon2id,
             version: Version::Version13,
-            mem_cost: std::env::var("MEMORY_COST")
-                .unwrap_or_default()
-                .parse::<u32>()
-                .unwrap_or(262144),
-            time_cost: std::env::var("ROUND")
-                .unwrap_or_default()
-                .parse::<u32>()
-                .unwrap_or(1),
-            lanes: 8,
-            secret: std::env::var("KEY")
-                .unwrap_or_else(|_| "KEY".to_string())
-                .as_bytes(),
-            ad: vanity,
-            hash_length: std::env::var("HASH_LENGTH")
-                .unwrap_or_default()
-                .parse::<u32>()
-                .unwrap_or(16),
+            mem_cost: config.memory_cost,
+            time_cost: config.round,
+            lanes: config.lanes,
+            secret: config.secret.as_bytes(),
+            ad: associated_data.unwrap_or(&[]),
+            hash_length: config.hash_length,
         },
     )
 }
@@ -81,7 +89,15 @@ mod tests {
     #[test]
     #[cfg(feature = "argon2")]
     fn test_argon2() {
-        let pwd = argon2(b"password", b"test").unwrap();
+        let config = Argon2Configuration {
+            memory_cost: 262144,
+            round: 1,
+            lanes: 8,
+            secret: "".to_string(),
+            hash_length: 16,
+        };
+
+        let pwd = argon2(config, b"password", Some(b"test")).unwrap();
 
         assert!(Regex::new(
             r"[$]argon2(i)?(d)?[$]v=[0-9]{1,2}[$]m=[0-9]+,t=[0-9]{1,},p=[0-9]{1,}[$].*"

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -6,7 +6,7 @@
 //! # Hash with SHA.
 //!
 //! ```rust
-//! println!("SHA256 of 'Hello world': {}", crypto::hash::sha256(b"Hello world").unwrap_or_default());
+//! println!("SHA256 of 'Hello world': {}", crypto::hash::sha256(b"Hello world"));
 //! ```
 
 #![forbid(unsafe_code)]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -20,6 +20,39 @@ pub mod encrypt;
 pub mod hash;
 
 use ring::rand::{SecureRandom, SystemRandom};
+use std::error::Error;
+use std::fmt;
+
+/// Error type for crypto errors.
+#[derive(Debug)]
+pub enum CryptoError {
+    /// An error with absolutely no details.
+    Unspecified,
+    /// An error when converting bytes to `String`.
+    UTF8Error,
+    /// Failed decoding hex value.
+    UnableDecodeHex,
+    /// Related to `fpe` crate.
+    InvalidRadix,
+    /// Related to `fpe` crate.
+    ExceedRadix,
+}
+
+impl fmt::Display for CryptoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CryptoError::Unspecified => write!(f, "Unknown error"),
+            CryptoError::UTF8Error => write!(f, "Bytes to `String` conversion failed."),
+            CryptoError::UnableDecodeHex => write!(f, "This error is linked to the `hex` crate. It is impossible to decode an input value."),
+            CryptoError::InvalidRadix => write!(f, "This error is linked to the `fpe` crate. The radix entered exceeds the maximum value (2..2^16)."),
+            CryptoError::ExceedRadix => write!(f, "This error is linked to the `fpe` crate. The input radix is too small for the expected output radix, increase the radix."),
+        }
+    }
+}
+
+impl Error for CryptoError {}
+
+const RADIX: u32 = 256;
 const CHARS: &str =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_%?!&";
 const CHARS_LENGTH: u8 = CHARS.len() as u8;

--- a/image_processor/src/host/cloudinary.rs
+++ b/image_processor/src/host/cloudinary.rs
@@ -41,13 +41,17 @@ pub struct Credentials {
 /// SHA1 buffer hash.
 pub async fn upload(credentials: Credentials, buffer: &[u8]) -> Result<String> {
     // Hash buffer image to obtain unique identifier.
-    let hash = sha1(buffer)?;
+    let hash = sha1(buffer);
 
     // Set public ID.
     let options = UploadOptions::new().set_public_id(hash.clone());
 
     // Set credentials.
-    let upload = Upload::new(credentials.key, credentials.cloud_name, credentials.secret);
+    let upload = Upload::new(
+        credentials.key,
+        credentials.cloud_name,
+        credentials.secret,
+    );
 
     // Create temporary file into the memory and write on it.
     let mut temp_file = NamedTempFile::new()?;


### PR DESCRIPTION
This PR wants totally remove `anyhow` crate
from `crypto` library. This should lead to a better
code and reduced binary size. (c. 32 bytes.)

Close #325.