### PR TITLE
feat: support token revocation

### DIFF
--- a/autha/src/helpers/queries.rs
+++ b/autha/src/helpers/queries.rs
@@ -21,7 +21,7 @@ pub async fn init(scylla: &Arc<Scylla>) -> Result<(), QueryError> {
         ("INSERT INTO accounts.salts (id, salt) VALUES (?, ?)", &CREATE_SALT),
         ("INSERT INTO accounts.oauth (id, user_id, bot_id, scope, deleted) VALUES (?, ?, ?, ?, ?) USING TTL 5184000", &CREATE_OAUTH),
         ("SELECT username, vanity, avatar, bio, email, birthdate, phone, verified, deleted, flags FROM accounts.users WHERE vanity = ?", &GET_USER),
-        ("SELECT id, user_id, bot_id, scope, deleted FROM accounts.oauth WHERE user_id = ?", &GET_USER_REFRESH_TOKEN)
+        ("SELECT bot_id, deleted, id, scope FROM accounts.oauth WHERE user_id = ?", &GET_USER_REFRESH_TOKEN)
     ];
 
     for (query, lock) in &prepared_queries {

--- a/autha/src/helpers/queries.rs
+++ b/autha/src/helpers/queries.rs
@@ -1,5 +1,6 @@
 use db::libscylla::{
-    prepared_statement::PreparedStatement, transport::errors::QueryError,
+    batch::Batch, prepared_statement::PreparedStatement,
+    transport::errors::QueryError,
 };
 use db::scylla::Scylla;
 use std::sync::{Arc, OnceLock};
@@ -9,151 +10,118 @@ pub static CREATE_TOKEN: OnceLock<PreparedStatement> = OnceLock::new();
 pub static CREATE_SALT: OnceLock<PreparedStatement> = OnceLock::new();
 pub static CREATE_OAUTH: OnceLock<PreparedStatement> = OnceLock::new();
 pub static GET_USER: OnceLock<PreparedStatement> = OnceLock::new();
-
-// Define constants for table creation and queries.
-const CREATE_USERS_TABLE: &str = r#"
-    CREATE TABLE IF NOT EXISTS users (
-        vanity TEXT,
-        email TEXT,
-        username TEXT,
-        avatar TEXT,
-        banner TEXT,
-        bio TEXT,
-        verified BOOLEAN,
-        flags INT,
-        locale TEXT,
-        phone TEXT,
-        password TEXT,
-        birthdate TEXT,
-        deleted BOOLEAN,
-        mfa_code TEXT,
-        expire_at TIMESTAMP,
-        PRIMARY KEY (vanity) );
-"#;
-const CREATE_BOTS_TABLE: &str = r#"
-    CREATE TABLE IF NOT EXISTS accounts.bots (
-        id TEXT,
-        user_id TEXT,
-        client_secret TEXT,
-        username TEXT,
-        avatar TEXT,
-        bio TEXT,
-        redirect_url SET<TEXT>,
-        flags INT,
-        deleted BOOLEAN,
-        PRIMARY KEY (id) )
-        WITH gc_grace_seconds = 604800;
-"#;
-const CREATE_OAUTH_TABLE: &str = r#"
-    CREATE TABLE IF NOT EXISTS accounts.oauth (
-        id TEXT,
-        user_id TEXT,
-        bot_id TEXT,
-        scope SET<TEXT>,
-        deleted BOOLEAN,
-        PRIMARY KEY (id) );
-"#;
-const CREATE_TOKENS_TABLE: &str = r#"
-    CREATE TABLE IF NOT EXISTS accounts.tokens (
-        id TEXT,
-        user_id TEXT,
-        ip TEXT,
-        date TIMESTAMP,
-        deleted BOOLEAN,
-        PRIMARY KEY (id) )
-        WITH default_time_to_live = 1210000
-        AND gc_grace_seconds = 604800;
-"#;
-const CREATE_SALTS_TABLE: &str = r#"
-    CREATE TABLE IF NOT EXISTS accounts.salts (
-        id TEXT,
-        salt TEXT,
-        PRIMARY KEY (id) );
-"#;
-const CREATE_USERS_INDEX_EMAIL: &str =
-    "CREATE INDEX IF NOT EXISTS ON accounts.users ( email );";
-const CREATE_USERS_INDEX_EXPIRE_AT: &str =
-    "CREATE INDEX IF NOT EXISTS ON accounts.users ( expire_at );";
-const CREATE_OAUTH_INDEX_USER_ID: &str =
-    "CREATE INDEX IF NOT EXISTS ON accounts.oauth ( user_id );";
-const CREATE_TOKENS_INDEX_USER_ID: &str =
-    "CREATE INDEX IF NOT EXISTS ON accounts.tokens ( user_id );";
-
-/// Define all the CQL queries for creating tables.
-const TABLES_TO_CREATE: [&str; 5] = [
-    CREATE_USERS_TABLE,
-    CREATE_BOTS_TABLE,
-    CREATE_OAUTH_TABLE,
-    CREATE_TOKENS_TABLE,
-    CREATE_SALTS_TABLE,
-];
-
-/// Define all the CQL queries for creating indexes.
-const INDICES_TO_CREATE: [&str; 4] = [
-    CREATE_USERS_INDEX_EMAIL,
-    CREATE_USERS_INDEX_EXPIRE_AT,
-    CREATE_OAUTH_INDEX_USER_ID,
-    CREATE_TOKENS_INDEX_USER_ID,
-];
+pub static GET_USER_REFRESH_TOKEN: OnceLock<PreparedStatement> =
+    OnceLock::new();
 
 /// Init prepared query to properly balance.
 /// This should improve the performance of queries, as well as providing better balancing.
 pub async fn init(scylla: &Arc<Scylla>) -> Result<(), QueryError> {
-    // Create user.
-    let create_query = scylla
-    .connection
-    .prepare(
-        "INSERT INTO accounts.users (vanity, email, username, password, locale, phone, birthdate, flags, deleted, verified, expire_at) VALUES (?, ?, ?, ?, ?, ?, ?, 0, false, false, 0)"
-    )
-    .await?;
-    CREATE_USER.get_or_init(|| create_query);
+    let prepared_queries = [
+        ("INSERT INTO accounts.users (vanity, email, username, password, locale, phone, birthdate, flags, deleted, verified, expire_at) VALUES (?, ?, ?, ?, ?, ?, ?, 0, false, false, 0)", &CREATE_USER),
+        ("INSERT INTO accounts.tokens (id, user_id, ip, date, deleted) VALUES (?, ?, ?, ?, false)", &CREATE_TOKEN),
+        ("INSERT INTO accounts.salts (id, salt) VALUES (?, ?)", &CREATE_SALT),
+        ("INSERT INTO accounts.oauth (id, user_id, bot_id, scope, deleted) VALUES (?, ?, ?, ?, ?) USING TTL 5184000", &CREATE_OAUTH),
+        ("SELECT username, vanity, avatar, bio, email, birthdate, phone, verified, deleted, flags FROM accounts.users WHERE vanity = ?", &GET_USER),
+        ("SELECT id, user_id, bot_id, scope, deleted FROM accounts.oauth WHERE user_id = ?", &GET_USER_REFRESH_TOKEN)
+    ];
 
-    // Create token.
-    let create_token = scylla
-    .connection
-    .prepare(
-        "INSERT INTO accounts.tokens (id, user_id, ip, date, deleted) VALUES (?, ?, ?, ?, false)"
-    )
-    .await?;
-    CREATE_TOKEN.get_or_init(|| create_token);
+    for (query, lock) in &prepared_queries {
+        let prepared_query =
+            scylla.connection.prepare(query.to_string()).await?;
 
-    // Create salt.
-    let create_salt = scylla
-        .connection
-        .prepare("INSERT INTO accounts.salts (id, salt) VALUES (?, ?)")
-        .await?;
-    CREATE_SALT.get_or_init(|| create_salt);
-
-    // Create oauth.
-    let create_oauth = scylla
-        .connection
-        .prepare(
-            "INSERT INTO accounts.oauth (id, user_id, bot_id, scope, deleted) VALUES (?, ?, ?, ?, ?) USING TTL 5184000"
-        )
-        .await?;
-    CREATE_OAUTH.get_or_init(|| create_oauth);
-
-    // Get user.
-    let get_user = scylla
-            .connection
-            .prepare(
-                "SELECT username, vanity, avatar, bio, email, birthdate, phone, verified, deleted, flags FROM accounts.users WHERE vanity = ?"
-            )
-            .await?;
-    GET_USER.get_or_init(|| get_user);
+        lock.get_or_init(|| prepared_query);
+    }
 
     Ok(())
 }
 
 /// Create tables on "accounts" keyspace.
 pub async fn create_tables(scylla: &Arc<Scylla>) -> Result<(), QueryError> {
-    for table in TABLES_TO_CREATE.iter() {
-        scylla.connection.query(table.to_string(), &[]).await?;
+    let tables = [
+        r#"
+                CREATE TABLE IF NOT EXISTS users (
+                    vanity TEXT,
+                    email TEXT,
+                    username TEXT,
+                    avatar TEXT,
+                    banner TEXT,
+                    bio TEXT,
+                    verified BOOLEAN,
+                    flags INT,
+                    locale TEXT,
+                    phone TEXT,
+                    password TEXT,
+                    birthdate TEXT,
+                    deleted BOOLEAN,
+                    mfa_code TEXT,
+                    expire_at TIMESTAMP,
+                    PRIMARY KEY (vanity) );
+            "#,
+        r#"
+                CREATE TABLE IF NOT EXISTS accounts.bots (
+                    id TEXT,
+                    user_id TEXT,
+                    client_secret TEXT,
+                    username TEXT,
+                    avatar TEXT,
+                    bio TEXT,
+                    redirect_url SET<TEXT>,
+                    flags INT,
+                    deleted BOOLEAN,
+                    PRIMARY KEY (id) )
+                    WITH gc_grace_seconds = 604800;
+            "#,
+        r#"
+                CREATE TABLE IF NOT EXISTS accounts.oauth (
+                    id TEXT,
+                    user_id TEXT,
+                    bot_id TEXT,
+                    scope SET<TEXT>,
+                    deleted BOOLEAN,
+                    PRIMARY KEY (id) );
+            "#,
+        r#"
+                CREATE TABLE IF NOT EXISTS accounts.tokens (
+                    id TEXT,
+                    user_id TEXT,
+                    ip TEXT,
+                    date TIMESTAMP,
+                    deleted BOOLEAN,
+                    PRIMARY KEY (id) )
+                    WITH default_time_to_live = 1210000
+                    AND gc_grace_seconds = 604800;
+            "#,
+        r#"
+                CREATE TABLE IF NOT EXISTS accounts.salts (
+                    id TEXT,
+                    salt TEXT,
+                    PRIMARY KEY (id) );
+            "#,
+    ];
+
+    // Define all the CQL queries for creating indexes.
+    let indexes: [&str; 4] = [
+        "CREATE INDEX IF NOT EXISTS ON accounts.users ( email );",
+        "CREATE INDEX IF NOT EXISTS ON accounts.users ( expire_at );",
+        "CREATE INDEX IF NOT EXISTS ON accounts.oauth ( user_id );",
+        "CREATE INDEX IF NOT EXISTS ON accounts.tokens ( user_id );",
+    ];
+
+    // Create batch to perform only one big call.
+    let mut batch = Batch::default();
+    let mut batch_value: Vec<()> = vec![];
+
+    for table in tables.iter() {
+        batch.append_statement(*table);
+        batch_value.push(());
     }
 
-    for index in INDICES_TO_CREATE.iter() {
-        scylla.connection.query(index.to_string(), &[]).await?;
+    for index in indexes.iter() {
+        batch.append_statement(*index);
+        batch_value.push(());
     }
+
+    scylla.connection.batch(&batch, batch_value).await?;
 
     Ok(())
 }

--- a/autha/src/main.rs
+++ b/autha/src/main.rs
@@ -241,7 +241,8 @@ async fn main() {
         .and(router::with_metric())
         .and(router::with_scylla(Arc::clone(&scylladb)))
         .and(warp::body::content_length_limit(5_000))
-        .and(warp::body::form())
+        // This should NOT be json but form do not work.
+        .and(warp::body::json())
         .and_then(router::oauth::revoke::revoke);
 
     #[cfg(feature = "telemetry")]

--- a/autha/src/main.rs
+++ b/autha/src/main.rs
@@ -209,7 +209,7 @@ async fn main() {
         .and(router::with_memcached(memcached_pool.clone()))
         .and(router::with_broker(Arc::clone(&broker)))
         .and(warp::header::<String>("authorization"))
-        .and(warp::body::content_length_limit(60_000_000)) // 600 MB.
+        .and(warp::body::content_length_limit(1024 * 500)) // 500kb.
         .and(warp::body::json())
         .and_then(router::update_user);
 

--- a/autha/src/model/body.rs
+++ b/autha/src/model/body.rs
@@ -84,3 +84,15 @@ pub struct OAuth {
     /// Bot access granted by the user.
     pub scope: Option<String>,
 }
+
+/// Represents the body structure for revoke access token and refresh token.
+#[derive(Deserialize)]
+#[allow(dead_code)]
+pub struct Revoke {
+    /// Access token or refresh token.
+    /// One of the two must be used to revoke the both.
+    pub token: String,
+    /// Should be access_token or refresh_token.
+    /// Due to automatic detection, it is not necessary to use it.
+    refresh_token: Option<String>,
+}

--- a/autha/src/router/mod.rs
+++ b/autha/src/router/mod.rs
@@ -35,14 +35,14 @@ impl warp::reject::Reject for UnknownError {}
 async fn vanity_from_token(scylla: &Arc<Scylla>, token: &str) -> Result<Token> {
     if token.starts_with("Bearer ") {
         let jwt_claims =
-            crate::helpers::token::get_jwt_data(&token.replace("Bearer ", ""))
+            crate::helpers::token::get_jwt(&token.replace("Bearer ", ""))
                 .map_err(|_| anyhow!("invalid token"))?;
 
         Ok(Token {
             token: token.to_string(),
-            vanity: jwt_claims.0,
+            vanity: jwt_claims.sub,
             is_bot: false,
-            scopes: Some(jwt_claims.1),
+            scopes: Some(jwt_claims.scope),
         })
     } else if token.starts_with("Bot ") {
         Err(anyhow!("bots are not supported"))
@@ -113,7 +113,7 @@ pub fn with_metric(
 }
 
 /// Handler of route to create a user.
-#[inline]
+#[inline(always)]
 pub async fn create_user(
     scylla: Arc<Scylla>,
     memcached: MemcachePool,
@@ -191,7 +191,7 @@ pub async fn login_user(
 }
 
 /// Handler of route to get a user.
-#[inline]
+#[inline(always)]
 pub async fn get_user(
     vanity: String,
     scylla: Arc<Scylla>,
@@ -214,7 +214,7 @@ pub async fn get_user(
 }
 
 /// Handler of route to update its account.
-#[inline]
+#[inline(always)]
 pub async fn update_user(
     scylla: Arc<Scylla>,
     memcached: MemcachePool,
@@ -238,7 +238,7 @@ pub async fn update_user(
 }
 
 /// Handler of route to create an authorization token.
-#[inline]
+#[inline(always)]
 pub async fn create_token(
     scylla: Arc<Scylla>,
     memcached: MemcachePool,
@@ -261,7 +261,7 @@ pub async fn create_token(
 }
 
 /// Handler of route to get access token after created authorization token.
-#[inline]
+#[inline(always)]
 pub async fn access_token(
     scylla: Arc<Scylla>,
     memcached: MemcachePool,

--- a/autha/src/router/oauth/client_credentials.rs
+++ b/autha/src/router/oauth/client_credentials.rs
@@ -57,6 +57,7 @@ pub async fn client_credentials(
 
     // Create access token.
     let (expires_in, access_token) = crate::helpers::token::create_jwt(
+        client_id.clone(),
         client_id,
         scopes.iter().map(|scope| scope.to_string()).collect(),
     )?;

--- a/autha/src/router/oauth/mod.rs
+++ b/autha/src/router/oauth/mod.rs
@@ -13,6 +13,7 @@ use warp::{
 };
 
 const VALID_SCOPE: [&str; 1] = ["identity"];
+const REFRESH_TOKEN_LENGTH: usize = 512;
 
 /// This route allows you to create an `authorization code` and then obtain an access token linked to a user.
 /// This is an implementation made for a grant type specified on `authorization_code`.

--- a/autha/src/router/oauth/mod.rs
+++ b/autha/src/router/oauth/mod.rs
@@ -1,6 +1,7 @@
 mod authorization_code;
 mod client_credentials;
 mod refresh;
+pub mod revoke;
 
 use anyhow::Result;
 use db::memcache::MemcachePool;

--- a/autha/src/router/oauth/refresh.rs
+++ b/autha/src/router/oauth/refresh.rs
@@ -17,22 +17,25 @@ pub async fn refresh_token(
     let rows = scylla
         .connection
         .query(
-            "SELECT user_id, scope, deleted FROM accounts.oauth WHERE id = ?",
+            "SELECT user_id, bot_id, scope, deleted FROM accounts.oauth WHERE id = ?",
             vec![&refresh_token],
         )
         .await?
-        .rows_typed::<(String, Vec<String>, bool)>()?
+        .rows_typed::<(String, String, Vec<String>, bool)>()?
         .collect::<Vec<_>>();
 
-    let (user_id, scopes, deleted) = rows[0].clone()?;
+    let (user_id, client_id, scopes, deleted) = rows[0].clone()?;
 
     if deleted {
         return Ok(crate::router::err("Expired refresh_token"));
     }
 
     // Create access token.
-    let (expires_in, access_token) =
-        crate::helpers::token::create_jwt(user_id, scopes.clone())?;
+    let (expires_in, access_token) = crate::helpers::token::create_jwt(
+        client_id.to_string(),
+        user_id,
+        scopes.clone(),
+    )?;
 
     Ok(warp::reply::with_status(
         warp::reply::json(&crate::model::response::AccessToken {

--- a/autha/src/router/oauth/refresh.rs
+++ b/autha/src/router/oauth/refresh.rs
@@ -24,6 +24,10 @@ pub async fn refresh_token(
         .rows_typed::<(String, String, Vec<String>, bool)>()?
         .collect::<Vec<_>>();
 
+    if rows.is_empty() {
+        return Ok(crate::router::err("Invalid refresh_token"));
+    }
+
     let (user_id, client_id, scopes, deleted) = rows[0].clone()?;
 
     if deleted {

--- a/autha/src/router/oauth/revoke.rs
+++ b/autha/src/router/oauth/revoke.rs
@@ -1,0 +1,89 @@
+use db::libscylla as scylla;
+use db::libscylla::macros::FromRow;
+use db::scylla::Scylla;
+use serde::Serialize;
+use std::{convert::Infallible, sync::Arc};
+use warp::http::StatusCode;
+
+use crate::helpers::{queries::GET_USER_REFRESH_TOKEN, token::get_jwt};
+
+/// Represents data related to a saved refresh token.
+#[derive(Serialize, FromRow, Debug, Default, Clone)]
+struct RefreshToken {
+    /// The client ID associated with the token.
+    pub bot_id: String,
+    /// Indicates whether the refresh token has been deleted.
+    pub deleted: bool,
+    /// The refresh token ID.
+    pub id: String,
+    /// The permissions granted by the token.
+    pub scope: Vec<String>,
+    /// The user's unique identifier.
+    pub user_id: String,
+}
+
+/// Handle access_token and refresh_token revocation from one of the tokens.
+pub async fn revoke(
+    scylla: Arc<Scylla>,
+    body: crate::model::body::Revoke,
+) -> Result<impl warp::Reply, Infallible> {
+    if body.token.len() >= super::REFRESH_TOKEN_LENGTH {
+        let _ = scylla
+            .connection
+            .query(
+                "DELETE FROM accounts.oauth WHERE id = ? IF EXISTS",
+                vec![body.token],
+            )
+            .await;
+    } else {
+        let claims = match get_jwt(&body.token) {
+            Ok(claims) => claims,
+            // Only return status 200 even if it fails as specified on rfc7009.
+            Err(_) => {
+                return Ok(warp::reply::with_status(
+                    warp::reply(),
+                    StatusCode::OK,
+                ))
+            },
+        };
+
+        let rows = match scylla
+            .connection
+            .execute(
+                GET_USER_REFRESH_TOKEN.get_or_init(|| unreachable!()),
+                vec![claims.sub],
+            )
+            .await
+            .unwrap_or_default()
+            .rows_typed::<RefreshToken>()
+        {
+            Ok(rows) => rows.collect::<Vec<_>>(),
+            Err(_) => {
+                return Ok(warp::reply::with_status(
+                    warp::reply(),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                ))
+            },
+        };
+
+        if let Some(Ok(refresh_token)) = rows.iter().find(|row| {
+            if let Ok(data) = row {
+                !data.deleted
+                    && data.bot_id == claims.client_id
+                    && claims.scope.eq(&data.scope)
+            } else {
+                false
+            }
+        }) {
+            let _ = scylla
+                .connection
+                .query(
+                    "DELETE FROM accounts.oauth WHERE id = ?",
+                    vec![refresh_token.clone().id],
+                )
+                .await;
+        };
+    }
+
+    Ok(warp::reply::with_status(warp::reply(), StatusCode::OK))
+}


### PR DESCRIPTION
This PR aims to allow a bot or a user to remove access from
an access token OR refresh token by deleting it from database.
It follows [RFC7009](https://datatracker.ietf.org/doc/html/rfc7009).